### PR TITLE
PHPORM-29: Add classes to cast ObjectId and UUID instances

### DIFF
--- a/src/Eloquent/Casts/BinaryUuid.php
+++ b/src/Eloquent/Casts/BinaryUuid.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Jenssegers\Mongodb\Eloquent\Casts;
+
+use function bin2hex;
+use function hex2bin;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Jenssegers\Mongodb\Eloquent\Model;
+use MongoDB\BSON\Binary;
+use function str_replace;
+use function substr;
+
+class BinaryUuid implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if (! $value instanceof Binary || $value->getType() !== Binary::TYPE_UUID) {
+            return $value;
+        }
+
+        $base16Uuid = bin2hex($value->getData());
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($base16Uuid, 0, 8),
+            substr($base16Uuid, 8, 4),
+            substr($base16Uuid, 12, 4),
+            substr($base16Uuid, 16, 4),
+            substr($base16Uuid, 20, 12),
+        );
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value instanceof Binary) {
+            return $value;
+        }
+
+        if (is_string($value) && strlen($value) === 16) {
+            return new Binary($value, Binary::TYPE_UUID);
+        }
+
+        return new Binary(hex2bin(str_replace('-', '', $value)), Binary::TYPE_UUID);
+    }
+}

--- a/src/Eloquent/Casts/ObjectId.php
+++ b/src/Eloquent/Casts/ObjectId.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Jenssegers\Mongodb\Eloquent\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Jenssegers\Mongodb\Eloquent\Model;
+use MongoDB\BSON\ObjectId as BSONObjectId;
+
+class ObjectId implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        if (! $value instanceof BSONObjectId) {
+            return $value;
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value instanceof BSONObjectId) {
+            return $value;
+        }
+
+        return new BSONObjectId($value);
+    }
+}

--- a/tests/Casts/BinaryUuidTest.php
+++ b/tests/Casts/BinaryUuidTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jenssegers\Mongodb\Tests\Casts;
+
+use Generator;
+use function hex2bin;
+use Jenssegers\Mongodb\Tests\Models\CastBinaryUuid;
+use Jenssegers\Mongodb\Tests\TestCase;
+use MongoDB\BSON\Binary;
+
+class BinaryUuidTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CastBinaryUuid::truncate();
+    }
+
+    /** @dataProvider provideBinaryUuidCast */
+    public function testBinaryUuidCastModel(string $expectedUuid, string|Binary $saveUuid, Binary $queryUuid): void
+    {
+        CastBinaryUuid::create(['uuid' => $saveUuid]);
+
+        $model = CastBinaryUuid::firstWhere('uuid', $queryUuid);
+        $this->assertNotNull($model);
+        $this->assertSame($expectedUuid, $model->uuid);
+    }
+
+    public static function provideBinaryUuidCast(): Generator
+    {
+        $uuid = '0c103357-3806-48c9-a84b-867dcb625cfb';
+        $binaryUuid = new Binary(hex2bin('0c103357380648c9a84b867dcb625cfb'), Binary::TYPE_UUID);
+
+        yield 'Save Binary, Query Binary' => [$uuid, $binaryUuid, $binaryUuid];
+        yield 'Save string, Query Binary' => [$uuid, $uuid, $binaryUuid];
+    }
+
+    public function testQueryByStringDoesNotCast(): void
+    {
+        $uuid = '0c103357-3806-48c9-a84b-867dcb625cfb';
+
+        CastBinaryUuid::create(['uuid' => $uuid]);
+
+        $model = CastBinaryUuid::firstWhere('uuid', $uuid);
+        $this->assertNull($model);
+    }
+}

--- a/tests/Casts/ObjectIdTest.php
+++ b/tests/Casts/ObjectIdTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jenssegers\Mongodb\Tests\Casts;
+
+use Generator;
+use Jenssegers\Mongodb\Tests\Models\CastObjectId;
+use Jenssegers\Mongodb\Tests\TestCase;
+use MongoDB\BSON\ObjectId;
+
+class ObjectIdTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        CastObjectId::truncate();
+    }
+
+    /** @dataProvider provideObjectIdCast */
+    public function testStoreObjectId(string|ObjectId $saveObjectId, ObjectId $queryObjectId): void
+    {
+        $stringObjectId = (string) $saveObjectId;
+
+        CastObjectId::create(['oid' => $saveObjectId]);
+
+        $model = CastObjectId::firstWhere('oid', $queryObjectId);
+        $this->assertNotNull($model);
+        $this->assertSame($stringObjectId, $model->oid);
+    }
+
+    public static function provideObjectIdCast(): Generator
+    {
+        $objectId = new ObjectId();
+        $stringObjectId = (string) $objectId;
+
+        yield 'Save ObjectId, Query ObjectId' => [$objectId, $objectId];
+        yield 'Save string, Query ObjectId' => [$stringObjectId, $objectId];
+    }
+
+    public function testQueryByStringDoesNotCast(): void
+    {
+        $objectId = new ObjectId();
+        $stringObjectId = (string) $objectId;
+
+        CastObjectId::create(['oid' => $objectId]);
+
+        $model = CastObjectId::firstWhere('oid', $stringObjectId);
+        $this->assertNull($model);
+    }
+}

--- a/tests/Models/CastBinaryUuid.php
+++ b/tests/Models/CastBinaryUuid.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jenssegers\Mongodb\Tests\Models;
+
+use Jenssegers\Mongodb\Eloquent\Casts\BinaryUuid;
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class CastBinaryUuid extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+    protected $casts = [
+        'uuid' => BinaryUuid::class,
+    ];
+}

--- a/tests/Models/CastObjectId.php
+++ b/tests/Models/CastObjectId.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jenssegers\Mongodb\Tests\Models;
+
+use Jenssegers\Mongodb\Eloquent\Casts\ObjectId;
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class CastObjectId extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+    protected $casts = [
+        'oid' => ObjectId::class,
+    ];
+}


### PR DESCRIPTION
This adds classes to cast ObjectIds and binary UUIDs to strings and vice-versa.

I've also added a test to confirm that casts are not applied when querying. While unfortunate, there's no way to add this functionality to Laravel as casting isn't exposed the way we need to cast in queries.