### PR TITLE
PHPORM-33: Add `Query::toMql()` and tests on query syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "license": "MIT",
     "require": {
-        "ext-mongodb": "*",
+        "ext-mongodb": "^1.15",
         "illuminate/support": "^10.0",
         "illuminate/container": "^10.0",
         "illuminate/database": "^10.0",

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -218,7 +218,7 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Return the MongoDB Query to be run in the form of an element array like ['method' => [arguments]].
+     * Return the MongoDB query to be run in the form of an element array like ['method' => [arguments]].
      *
      * Example: ['find' => [['name' => 'John Doe'], ['projection' => ['birthday' => 1]]]]
      *

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1273,10 +1273,7 @@ class QueryBuilderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $builder = $this->getBuilder();
         $builder->whereIn('id', [
-            [
-                'a' => 1,
-                'b' => 1,
-            ],
+            ['a' => 1, 'b' => 1],
             ['c' => 2],
             [3],
         ]);
@@ -1474,7 +1471,8 @@ class QueryBuilderTest extends TestCase
         $this->assertSame(['find' => [[], ['sort' => ['created_at' => -1], 'limit' => 1, 'typeMap' => ['root' => 'array', 'document' => 'array']]]], $builder->toMql());
 
         $builder = $this->getBuilder();
-        $builder->latest('updated_at');$this->assertSame(['find' => [[], ['sort' => ['updated_at' => -1], 'typeMap' => ['root' => 'array', 'document' => 'array']]]], $builder->toMql());
+        $builder->latest('updated_at');
+        $this->assertSame(['find' => [[], ['sort' => ['updated_at' => -1], 'typeMap' => ['root' => 'array', 'document' => 'array']]]], $builder->toMql());
     }
 
     /** @see DatabaseQueryBuilderTest::testOldest() */
@@ -1489,7 +1487,8 @@ class QueryBuilderTest extends TestCase
         $this->assertSame(['find' => [[], ['sort' => ['created_at' => 1], 'limit' => 1, 'typeMap' => ['root' => 'array', 'document' => 'array']]]], $builder->toMql());
 
         $builder = $this->getBuilder();
-        $builder->oldest('updated_at');$this->assertSame(['find' => [[], ['sort' => ['updated_at' => 1], 'typeMap' => ['root' => 'array', 'document' => 'array']]]], $builder->toMql());
+        $builder->oldest('updated_at');
+        $this->assertSame(['find' => [[], ['sort' => ['updated_at' => 1], 'typeMap' => ['root' => 'array', 'document' => 'array']]]], $builder->toMql());
     }
 
     /** @see DatabaseQueryBuilderTest::testReorder() */


### PR DESCRIPTION
Fix [PHPORM-33](https://jira.mongodb.org/browse/PHPORM-33)

This is the preliminary work before writing all the tests. It presents 2 ways of writing the tests:
* The "integration" way: currently, the query features are tested by checking the query results. Each test have to initialise some collection data. The tests require a running server and can't run in parallel. 
*We could use the driver events to track the query, but it too deep and may change with server version and maybe the connection string.*
* The "unit" way: assertion are written on the query. I created the `toMql()` method for that. 


### In this PR
* Add the method `Mongodb\Query\Builder::toMql()` to mimic the `Illuminate\Database\Query::toSql()`. No need for a [`toRawSql()`](https://twitter.com/taylorotwell/status/1674423823163338764) equivalent because there is no data binding.
* Import tests from [`Illuminate\Tests\Database\DatabaseQueryBuilderTest`](https://github.com/laravel/framework/blob/10.x/tests/Database/DatabaseQueryBuilderTest.php)


### The MQL format (my proposition)

[MQL is a javascript-like format](https://www.mongodb.com/basics/examples#querying-mongodb-collections).

The collection name is not in the dumped format.
```js
db.users.find().skip(5).take(10)
```
```php
[
    'find' => [[], ['skip' => 5, 'limit' => 10]],
]
```
Or in split version:
```php
[
    'find' => [],
    'skip' => [5],
    'take' => [10],
]
```

When chaining, add several calls to the array. This does not accept calls to the same method. But the query builder never use method chaining.
```js
db.users.find({"name.family": "Smith"}).count()
```

```php
[
    'find' => [['name.family' => 'Smith']],
    'count' => [],
]
```

