### PR TITLE
PHPORM-44: Throw an exception when Query\Builder::push() is used incorrectly

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -786,9 +786,12 @@ class Builder extends BaseBuilder
         $operator = $unique ? '$addToSet' : '$push';
 
         // Check if we are pushing multiple values.
-        $batch = (is_array($value) && array_keys($value) === range(0, count($value) - 1));
+        $batch = is_array($value) && array_is_list($value);
 
         if (is_array($column)) {
+            if ($value !== null) {
+                throw new \InvalidArgumentException(sprintf('2nd argument of %s() must be "null" when 1st argument is an array. Got "%s" instead.', __METHOD__, get_debug_type($value)));
+            }
             $query = [$operator => $column];
         } elseif ($batch) {
             $query = [$operator => [$column => ['$each' => $value]]];

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -345,6 +345,14 @@ class QueryBuilderTest extends TestCase
         $this->assertCount(3, $user['messages']);
     }
 
+    public function testPushRefuses2ndArgumentWhen1stIsAnArray()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('2nd argument of Jenssegers\Mongodb\Query\Builder::push() must be "null" when 1st argument is an array. Got "string" instead.');
+
+        DB::collection('users')->push(['tags' => 'tag1'], 'tag2');
+    }
+
     public function testPull()
     {
         $message1 = ['from' => 'Jane', 'body' => 'Hi John'];


### PR DESCRIPTION
Fix [PHPORM-44](https://jira.mongodb.org/browse/PHPORM-44)

Related to https://github.com/GromNaN/laravel-mongodb-private/pull/3/files#r1257886662