### PR TITLE
PHPORM-46 Throw an exception when Query\Builder::orderBy() is used with invalid direction

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -513,7 +513,7 @@ class Builder extends BaseBuilder
 
     /**
      * @inheritdoc
-     * @param  int|string  $direction
+     * @param int|string|array $direction
      */
     public function orderBy($column, $direction = 'asc')
     {

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Jenssegers\Mongodb\Tests\Query;
 
 use DateTimeImmutable;
+use Illuminate\Tests\Database\DatabaseQueryBuilderTest;
 use Jenssegers\Mongodb\Connection;
 use Jenssegers\Mongodb\Query\Builder;
 use Jenssegers\Mongodb\Query\Processor;
@@ -63,6 +64,66 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->limit(10)->offset(5)->select('foo', 'bar'),
         ];
 
+        /** @see DatabaseQueryBuilderTest::testOrderBys() */
+        yield 'orderBy multiple columns' => [
+            ['find' => [[], ['sort' => ['email' => 1, 'age' => -1]]]],
+            fn (Builder $builder) => $builder
+                ->orderBy('email')
+                ->orderBy('age', 'desc'),
+        ];
+
+        yield 'orders = null' => [
+            ['find' => [[], []]],
+            function (Builder $builder) {
+                $builder->orders = null;
+
+                return $builder;
+            },
+        ];
+
+        yield 'orders = []' => [
+            ['find' => [[], []]],
+            function (Builder $builder) {
+                $builder->orders = [];
+
+                return $builder;
+            },
+        ];
+
+        yield 'multiple orders with direction' => [
+            ['find' => [[], ['sort' => ['email' => -1, 'age' => 1]]]],
+            fn (Builder $builder) => $builder
+                ->orderBy('email', -1)
+                ->orderBy('age', 1),
+        ];
+
+        yield 'orderByDesc' => [
+            ['find' => [[], ['sort' => ['email' => -1]]]],
+            fn (Builder $builder) => $builder->orderByDesc('email'),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testReorder() */
+        yield 'reorder reset' => [
+            ['find' => [[], []]],
+            fn (Builder $builder) => $builder->orderBy('name')->reorder(),
+        ];
+
+        yield 'reorder column' => [
+            ['find' => [[], ['sort' => ['name' => -1]]]],
+            fn (Builder $builder) => $builder->orderBy('name')->reorder('name', 'desc'),
+        ];
+
+        /** @link https://www.mongodb.com/docs/manual/reference/method/cursor.sort/#text-score-metadata-sort */
+        yield 'orderBy array meta' => [
+            ['find' => [
+                ['$text' => ['$search' => 'operating']],
+                ['sort' => ['score' => ['$meta' => 'textScore']]],
+            ]],
+            fn (Builder $builder) => $builder
+                ->where('$text', ['$search' => 'operating'])
+                ->orderBy('score', ['$meta' => 'textScore']),
+        ];
+
         yield 'distinct' => [
             ['distinct' => ['foo', [], []]],
             fn (Builder $builder) => $builder->distinct('foo'),
@@ -71,6 +132,27 @@ class BuilderTest extends TestCase
         yield 'groupBy' => [
             ['aggregate' => [[['$group' => ['_id' => ['foo' => '$foo'], 'foo' => ['$last' => '$foo']]]], []]],
             fn (Builder $builder) => $builder->groupBy('foo'),
+        ];
+    }
+
+    /**
+     * @dataProvider provideExceptions
+     */
+    public function testException($class, $message, \Closure $build): void
+    {
+        $builder = self::getBuilder();
+
+        $this->expectException($class);
+        $this->expectExceptionMessage($message);
+        $build($builder);
+    }
+
+    public static function provideExceptions(): iterable
+    {
+        yield 'orderBy invalid direction' => [
+            \InvalidArgumentException::class,
+            'Order direction must be "asc" or "desc"',
+            fn (Builder $builder) => $builder->orderBy('_id', 'dasc'),
         ];
     }
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -863,11 +863,4 @@ class QueryBuilderTest extends TestCase
             $this->assertEquals($data[$i]['name'], $result['name']);
         }
     }
-
-    public function testOrderByInvalidDirection()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Order direction must be "asc" or "desc"');
-        DB::collection('items')->orderBy('_id', 'dasc')->get();
-    }
 }


### PR DESCRIPTION
Fix [PHPORM-46](https://jira.mongodb.org/browse/PHPORM-46)

Consistent with [Laravel Query Builder](https://github.com/laravel/framework/blob/v10.15.0/src/Illuminate/Database/Query/Builder.php#L2314-L2316).
