### PR TITLE
PHPORM-47 Improve Builder::whereBetween to support CarbonPeriod and reject invalid array

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -555,7 +555,7 @@ class Builder extends BaseBuilder
 
     /**
      * @inheritdoc
-     * @param array{mixed, mixed}|CarbonPeriod $values
+     * @param list{mixed, mixed}|CarbonPeriod $values
      */
     public function whereBetween($column, iterable $values, $boolean = 'and', $not = false)
     {

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -136,17 +136,6 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->whereBetween('id', [[1], [2, 3]]),
         ];
 
-        yield 'whereNotBetween array of numbers' => [
-            ['find' => [
-                ['$or' => [
-                    ['id' => ['$lte' => 1]],
-                    ['id' => ['$gte' => 2]],
-                ]],
-                [], // options
-            ]],
-            fn (Builder $builder) => $builder->whereNotBetween('id', [1, 2]),
-        ];
-
         $period = now()->toPeriod(now()->addMonth());
         yield 'whereBetween CarbonPeriod' => [
             ['find' => [
@@ -200,6 +189,17 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder
                 ->where('id', '=', 1)
                 ->orWhereBetween('id', collect([3, 4])),
+        ];
+
+        yield 'whereNotBetween array of numbers' => [
+            ['find' => [
+                ['$or' => [
+                    ['id' => ['$lte' => 1]],
+                    ['id' => ['$gte' => 2]],
+                ]],
+                [], // options
+            ]],
+            fn (Builder $builder) => $builder->whereNotBetween('id', [1, 2]),
         ];
 
         /** @see DatabaseQueryBuilderTest::testOrWhereNotBetween() */
@@ -292,6 +292,12 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->whereBetween('id', [1]),
         ];
 
+        yield 'whereBetween array too short (nested)' => [
+            \InvalidArgumentException::class,
+            'Between $values must be a list with exactly two elements: [min, max]',
+            fn (Builder $builder) => $builder->whereBetween('id', [[1, 2]]),
+        ];
+
         yield 'whereBetween array too long' => [
             \InvalidArgumentException::class,
             'Between $values must be a list with exactly two elements: [min, max]',
@@ -308,12 +314,6 @@ class BuilderTest extends TestCase
             \InvalidArgumentException::class,
             'Between $values must be a list with exactly two elements: [min, max]',
             fn (Builder $builder) => $builder->whereBetween('id', ['min' => 1, 'max' => 2]),
-        ];
-
-        yield 'whereBetween array too short (nested)' => [
-            \InvalidArgumentException::class,
-            'Between $values must be a list with exactly two elements: [min, max]',
-            fn (Builder $builder) => $builder->whereBetween('id', [[1, 2]]),
         ];
     }
 


### PR DESCRIPTION
Fix [PHPORM-47](https://jira.mongodb.org/browse/PHPORM-47)

The `Query\Builder::whereBetween()` method can be used like this:
```
whereBetween('date_field', [min, max])
whereBetween('date_field', collect([min, max]))
whereBetween('date_field', CarbonPeriod)
```

Laravel allows other formats: the `$values` array is flatten and the builder assumes there are at least 2 elements and ignore the others. It's a design that can lead to misunderstandings. I prefer to raise an exception when we have incorrect values, rather than trying to guess what the developer would like to do.


Support for CarbonPeriod was fixed in Laravel 10: https://github.com/laravel/framework/pull/46720 because the query builder was taking the 1st 2 values of the iterator instead of the start & end dates.