### PR TITLE
PHPORM-33 Add tests on Query\Builder methods

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -925,6 +925,10 @@ class Builder extends BaseBuilder
             }
         }
 
+        if (func_num_args() == 1 && is_string($column)) {
+            throw new \ArgumentCountError(sprintf('Too few arguments to function %s("%s"), 1 passed and at least 2 expected when the 1st is a string.', __METHOD__, $column));
+        }
+
         return parent::where(...$params);
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1378,4 +1378,28 @@ class Builder extends BaseBuilder
     {
         throw new \BadMethodCallException('This method is not supported by MongoDB');
     }
+
+    /** @internal This method is not supported by MongoDB. */
+    public function whereIntegerInRaw($column, $values, $boolean = 'and', $not = false)
+    {
+        throw new \BadMethodCallException('This method is not supported by MongoDB');
+    }
+
+    /** @internal This method is not supported by MongoDB. */
+    public function orWhereIntegerInRaw($column, $values)
+    {
+        throw new \BadMethodCallException('This method is not supported by MongoDB');
+    }
+
+    /** @internal This method is not supported by MongoDB. */
+    public function whereIntegerNotInRaw($column, $values, $boolean = 'and')
+    {
+        throw new \BadMethodCallException('This method is not supported by MongoDB');
+    }
+
+    /** @internal This method is not supported by MongoDB. */
+    public function orWhereIntegerNotInRaw($column, $values, $boolean = 'and')
+    {
+        throw new \BadMethodCallException('This method is not supported by MongoDB');
+    }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -333,10 +333,44 @@ class BuilderTest extends TestCase
                 ]),
         ];
 
+
         /** @see DatabaseQueryBuilderTest::testForPage() */
         yield 'forPage' => [
             ['find' => [[], ['limit' => 20, 'skip' => 40]]],
             fn (Builder $builder) => $builder->forPage(3, 20),
+        ];
+
+        yield 'skip limit' => [
+            ['find' => [[], ['skip' => 5, 'limit' => 10]]],
+            fn (Builder $builder) => $builder->offset(5)->limit(10),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testLimitsAndOffsets() */
+        yield 'offset limit' => [
+            ['find' => [[], ['skip' => 5, 'limit' => 10]]],
+            fn (Builder $builder) => $builder->offset(5)->limit(10),
+        ];
+
+        yield 'offset 0 limit 0' => [
+            ['find' => [[], []]],
+            fn (Builder $builder) => $builder->offset(0)->limit(0),
+        ];
+
+        yield 'offset limit negative' => [
+            ['find' => [[], []]],
+            fn (Builder $builder) => $builder->offset(-5)->limit(-10),
+        ];
+
+        yield 'offset limit null (reset)' => [
+            ['find' => [[], []]],
+            fn (Builder $builder) => $builder
+                ->offset(5)->limit(10)
+                ->offset(null)->limit(null),
+        ];
+
+        yield 'skip take (aliases)' => [
+            ['find' => [[], ['skip' => 5, 'limit' => 10]]],
+            fn (Builder $builder) => $builder->skip(5)->limit(10),
         ];
 
         /** @see DatabaseQueryBuilderTest::testOrderBys() */
@@ -542,6 +576,38 @@ class BuilderTest extends TestCase
             ['distinct' => ['foo', [], []]],
             fn (Builder $builder) => $builder->distinct('foo')
                 ->select('foo', 'bar'),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testLatest() */
+        yield 'latest' => [
+            ['find' => [[], ['sort' => ['created_at' => -1]]]],
+            fn (Builder $builder) => $builder->latest(),
+        ];
+
+        yield 'latest limit' => [
+            ['find' => [[], ['sort' => ['created_at' => -1], 'limit' => 1]]],
+            fn (Builder $builder) => $builder->latest()->limit(1),
+        ];
+
+        yield 'latest custom field' => [
+            ['find' => [[], ['sort' => ['updated_at' => -1]]]],
+            fn (Builder $builder) => $builder->latest('updated_at'),
+        ];
+
+        /** @see DatabaseQueryBuilderTest::testOldest() */
+        yield 'oldest' => [
+            ['find' => [[], ['sort' => ['created_at' => 1]]]],
+            fn (Builder $builder) => $builder->oldest(),
+        ];
+
+        yield 'oldest limit' => [
+            ['find' => [[], ['sort' => ['created_at' => 1], 'limit' => 1]]],
+            fn (Builder $builder) => $builder->oldest()->limit(1),
+        ];
+
+        yield 'oldest custom field' => [
+            ['find' => [[], ['sort' => ['updated_at' => 1]]]],
+            fn (Builder $builder) => $builder->oldest('updated_at'),
         ];
 
         yield 'groupBy' => [

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -345,14 +345,23 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->offset(5)->limit(10),
         ];
 
-        yield 'offset 0 limit 0' => [
+        yield 'offset limit zero (unset)' => [
             ['find' => [[], []]],
-            fn (Builder $builder) => $builder->offset(0)->limit(0),
+            fn (Builder $builder) => $builder
+                ->offset(0)->limit(0),
         ];
 
-        yield 'offset limit negative' => [
+        yield 'offset limit zero (reset)' => [
             ['find' => [[], []]],
-            fn (Builder $builder) => $builder->offset(-5)->limit(-10),
+            fn (Builder $builder) => $builder
+                ->offset(5)->limit(10)
+                ->offset(0)->limit(0),
+        ];
+
+        yield 'offset limit negative (unset)' => [
+            ['find' => [[], []]],
+            fn (Builder $builder) => $builder
+                ->offset(-5)->limit(-10),
         ];
 
         yield 'offset limit null (reset)' => [

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -332,7 +332,7 @@ class TransactionTest extends TestCase
         $count = User::count();
         $this->assertEquals(2, $count);
 
-        $this->assertTrue(User::where('alcaeus')->exists());
+        $this->assertTrue(User::where('name', 'alcaeus')->exists());
         $this->assertTrue(User::where(['name' => 'klinson'])->where('age', 21)->exists());
     }
 


### PR DESCRIPTION
Fix [PHPORM-33](https://jira.mongodb.org/browse/PHPORM-33)
Replace #4

- Add tests on query builder methods that don't need to be fixed.
- Throw exception when calling unsupported methods: `whereIntegerInRaw`, `orWhereIntegerInRaw`, `whereIntegerNotInRaw`, `orWhereIntegerNotInRaw`
- Throw an exception when `Query\Builder::where` is called with only a column name