### PR TITLE
PHPORM-63 Remove unused public property `Query\Builder::$paginating`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Throw an exception for unsupported `Query\Builder` methods [#9](https://github.com/GromNaN/laravel-mongodb-private/pull/9) by [@GromNaN](https://github.com/GromNaN).
 - Throw an exception when `Query\Builder::orderBy()` is used with invalid direction [#7](https://github.com/GromNaN/laravel-mongodb-private/pull/7) by [@GromNaN](https://github.com/GromNaN).
 - Throw an exception when `Query\Builder::push()` is used incorrectly [#5](https://github.com/GromNaN/laravel-mongodb-private/pull/5) by [@GromNaN](https://github.com/GromNaN).
+- Remove public property `Query\Builder::$paginating` [#15](https://github.com/GromNaN/laravel-mongodb-private/pull/15) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -60,13 +60,6 @@ class Builder extends BaseBuilder
     public $options = [];
 
     /**
-     * Indicate if we are executing a pagination query.
-     *
-     * @var bool
-     */
-    public $paginating = false;
-
-    /**
      * All of the available clause operators.
      *
      * @var array
@@ -572,16 +565,6 @@ class Builder extends BaseBuilder
         $this->wheres[] = compact('column', 'type', 'boolean', 'values', 'not');
 
         return $this;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function forPage($page, $perPage = 15)
-    {
-        $this->paginating = true;
-
-        return $this->skip(($page - 1) * $perPage)->take($perPage);
     }
 
     /**

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -247,6 +247,12 @@ class BuilderTest extends TestCase
                 ]),
         ];
 
+        /** @see DatabaseQueryBuilderTest::testForPage() */
+        yield 'forPage' => [
+            ['find' => [[], ['limit' => 20, 'skip' => 40]]],
+            fn (Builder $builder) => $builder->forPage(3, 20),
+        ];
+
         /** @see DatabaseQueryBuilderTest::testOrderBys() */
         yield 'orderBy multiple columns' => [
             ['find' => [[], ['sort' => ['email' => 1, 'age' => -1]]]],


### PR DESCRIPTION
Fix [PHPORM-63](https://jira.mongodb.org/browse/PHPORM-63)

`Query\Builder::$paginating` is initialized by `Query\Builder::forPage` but never used.

Introduced by https://github.com/jenssegers/laravel-mongodb/commit/9603949160360173a44b46259f43ce62af76607e it was never removed when it stopped being used in https://github.com/jenssegers/laravel-mongodb/commit/a8918acadb79f4f90d42eaddf0e996054ddd8184