### PR TITLE
PHPORM-64 Remove `Query\Builder::whereAll($field, $values)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Remove public property `Query\Builder::$paginating` [#15](https://github.com/GromNaN/laravel-mongodb-private/pull/15) by [@GromNaN](https://github.com/GromNaN).
 - Remove call to deprecated `Collection::count` for `countDocuments` [#18](https://github.com/GromNaN/laravel-mongodb-private/pull/18) by [@GromNaN](https://github.com/GromNaN).
 - Accept operators prefixed by `$` in `Query\Builder::orWhere` [#20](https://github.com/GromNaN/laravel-mongodb-private/pull/20) by [@GromNaN](https://github.com/GromNaN).
+- Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/README.md
+++ b/README.md
@@ -483,6 +483,17 @@ Car::where('weight', 300)
 
 ### MongoDB-specific operators
 
+In addition to the Laravel Eloquent operators, all available MongoDB query operators can be used with `where`:
+
+```php
+User::where($fieldName, $operator, $value)->get();
+```
+
+It generates the following MongoDB filter:
+```ts
+{ $fieldName: { $operator: $value } }
+```
+
 **Exists**
 
 Matches documents that have the specified field.

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -531,24 +531,6 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Add a "where all" clause to the query.
-     *
-     * @param  string  $column
-     * @param  array  $values
-     * @param  string  $boolean
-     * @param  bool  $not
-     * @return $this
-     */
-    public function whereAll($column, array $values, $boolean = 'and', $not = false)
-    {
-        $type = 'all';
-
-        $this->wheres[] = compact('column', 'type', 'boolean', 'values', 'not');
-
-        return $this;
-    }
-
-    /**
      * @inheritdoc
      * @param list{mixed, mixed}|CarbonPeriod $values
      */
@@ -1042,17 +1024,6 @@ class Builder extends BaseBuilder
         }
 
         return $compiled;
-    }
-
-    /**
-     * @param  array  $where
-     * @return array
-     */
-    protected function compileWhereAll(array $where): array
-    {
-        extract($where);
-
-        return [$column => ['$all' => array_values($values)]];
     }
 
     /**

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -333,6 +333,22 @@ class BuilderTest extends TestCase
                 ]),
         ];
 
+        yield 'where all' => [
+            ['find' => [['tags' => ['$all' => ['ssl', 'security']]], []]],
+            fn (Builder $builder) => $builder->where('tags', 'all', ['ssl', 'security']),
+        ];
+
+        yield 'where all nested operators' => [
+            ['find' => [['tags' => ['$all' => [
+                ['$elemMatch' => ['size' => 'M', 'num' => ['$gt' => 50]]],
+                ['$elemMatch' => ['num' => 100, 'color' => 'green']],
+            ]]], []]],
+            fn (Builder $builder) => $builder->where('tags', 'all', [
+                ['$elemMatch' => ['size' => 'M', 'num' => ['$gt' => 50]]],
+                ['$elemMatch' => ['num' => 100, 'color' => 'green']],
+            ]),
+        ];
+
         /** @see DatabaseQueryBuilderTest::testForPage() */
         yield 'forPage' => [
             ['find' => [[], ['limit' => 20, 'skip' => 40]]],


### PR DESCRIPTION
Fix [PHPORM-64](https://jira.mongodb.org/browse/PHPORM-64)

Use `where($field, 'all', $values)` instead.

Introduced in 2017 without explaining the motivation https://github.com/jenssegers/laravel-mongodb/pull/1320