### PR TITLE
PHPORM-53 Fix and test `like` and `regex` operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ All notable changes to this project will be documented in this file.
 - Accept operators prefixed by `$` in `Query\Builder::orWhere` [#20](https://github.com/GromNaN/laravel-mongodb-private/pull/20) by [@GromNaN](https://github.com/GromNaN).
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
-- Fix support for `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
-- Remove `ilike` and `regexp` operators, use `like` and `regex` instead [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
+- Support `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Add classes to cast ObjectId and UUID instances [#1](https://github.com/GromNaN/laravel-mongodb-private/pull/1) by [@alcaeus](https://github.com/alcaeus).
+- Add classes to cast `ObjectId` and `UUID` instances [#1](https://github.com/GromNaN/laravel-mongodb-private/pull/1) by [@alcaeus](https://github.com/alcaeus).
 - Add `Query\Builder::toMql()` to simplify comprehensive query tests [#6](https://github.com/GromNaN/laravel-mongodb-private/pull/6) by [@GromNaN](https://github.com/GromNaN).
 - Fix `Query\Builder::whereNot` to use MongoDB [`$not`](https://www.mongodb.com/docs/manual/reference/operator/query/not/) operator [#13](https://github.com/GromNaN/laravel-mongodb-private/pull/13) by [@GromNaN](https://github.com/GromNaN).
 - Fix `Query\Builder::whereBetween` to accept `Carbon\Period` object [#10](https://github.com/GromNaN/laravel-mongodb-private/pull/10) by [@GromNaN](https://github.com/GromNaN).
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 - Accept operators prefixed by `$` in `Query\Builder::orWhere` [#20](https://github.com/GromNaN/laravel-mongodb-private/pull/20) by [@GromNaN](https://github.com/GromNaN).
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
+- Fix support for `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
+- Remove `ilike` and `regexp` operators, use `like` and `regex` instead [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1052,6 +1052,7 @@ class Builder extends BaseBuilder
         if (in_array($operator, ['regex', 'not regex'])) {
             // Automatically convert regular expression strings to Regex objects.
             if (is_string($value)) {
+                // Detect the delimiter and validate the preg pattern
                 $delimiter = substr($value, 0, 1);
                 if (! in_array($delimiter, self::REGEX_DELIMITERS)) {
                     throw new \LogicException(sprintf('Missing expected starting delimiter in regular expression "%s", supported delimiters are: %s', $value, implode(' ', self::REGEX_DELIMITERS)));
@@ -1060,8 +1061,12 @@ class Builder extends BaseBuilder
                 if (count($e) < 3) {
                     throw new \LogicException(sprintf('Missing expected ending delimiter "%s" in regular expression "%s"', $delimiter, $value));
                 }
+                // Flags are after the last delimiter
                 $flags = end($e);
+                // Extract the regex string between the delimiters
                 $regstr = substr($value, 1, -1 - strlen($flags));
+                // Unescape forward slashes
+                $regstr = stripslashes($regstr);
                 $value = new Regex($regstr, $flags);
             }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1075,8 +1075,6 @@ class Builder extends BaseBuilder
                 $flags = end($e);
                 // Extract the regex string between the delimiters
                 $regstr = substr($value, 1, -1 - strlen($flags));
-                // Unescape forward slashes
-                $regstr = stripslashes($regstr);
                 $value = new Regex($regstr, $flags);
             }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -635,9 +635,9 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('name', 'regex', '#^acme$#si'),
         ];
 
-        yield 'where regex with escaped forward slash' => [
-            ['find' => [['name' => new Regex('ac/me', '')], []]],
-            fn (Builder $builder) => $builder->where('name', 'regex', '/ac\/me/'),
+        yield 'where regex with escaped characters' => [
+            ['find' => [['name' => new Regex('a\.c\/m\+e', '')], []]],
+            fn (Builder $builder) => $builder->where('name', 'regex', '/a\.c\/m\+e/'),
         ];
 
         yield 'where not regex' => [

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -635,8 +635,8 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('name', 'regex', '#^acme$#si'),
         ];
 
-        yield 'where regex escaped delimiter' => [
-            ['find' => [['name' => new Regex('ac\/me', '')], []]],
+        yield 'where regex with escaped forward slash' => [
+            ['find' => [['name' => new Regex('ac/me', '')], []]],
             fn (Builder $builder) => $builder->where('name', 'regex', '/ac\/me/'),
         ];
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -584,6 +584,11 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('name', 'like', 'acme'),
         ];
 
+        yield 'where ilike' => [ // Alias for like
+            ['find' => [['name' => new Regex('^acme$', 'i')], []]],
+            fn (Builder $builder) => $builder->where('name', 'ilike', 'acme'),
+        ];
+
         yield 'where like escape' => [
             ['find' => [['name' => new Regex('^\^ac\.me\$$', 'i')], []]],
             fn (Builder $builder) => $builder->where('name', 'like', '^ac.me$'),
@@ -608,6 +613,11 @@ class BuilderTest extends TestCase
         yield 'where BSON\Regex' => [
             ['find' => [['name' => $regex], []]],
             fn (Builder $builder) => $builder->where('name', 'regex', $regex),
+        ];
+
+        yield 'where regexp' => [ // Alias for regex
+            ['find' => [['name' => $regex], []]],
+            fn (Builder $builder) => $builder->where('name', 'regex', '/^acme$/si'),
         ];
 
         yield 'where regex delimiter /' => [
@@ -746,7 +756,6 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->whereBetween('id', ['min' => 1, 'max' => 2]),
         ];
 
-
         yield 'find with single string argument' => [
             \ArgumentCountError::class,
             'Too few arguments to function Jenssegers\Mongodb\Query\Builder::where("foo"), 1 passed and at least 2 expected when the 1st is a string',
@@ -755,32 +764,14 @@ class BuilderTest extends TestCase
 
         yield 'where regex not starting with /' => [
             \LogicException::class,
-            'Regular expressions must be surrounded by delimiter "/". Got "^ac/me$"',
+            'Missing expected starting delimiter in regular expression "^ac/me$", supported delimiters are: / # ~',
             fn (Builder $builder) => $builder->where('name', 'regex', '^ac/me$'),
         ];
 
         yield 'where regex not ending with /' => [
             \LogicException::class,
-            'Regular expressions must be surrounded by delimiter "/". Got "/^acme$"',
-            fn (Builder $builder) => $builder->where('name', 'regex', '/^acme$'),
-        ];
-
-        yield 'where regex not ending with #' => [
-            \LogicException::class,
-            'Regular expressions must be surrounded by delimiter "#". Got "#^acme$"',
-            fn (Builder $builder) => $builder->where('name', 'regex', '#^acme$'),
-        ];
-
-        yield 'where regexp not supported' => [
-            \LogicException::class,
-            'Operator "regexp" is not supported. Use "regex" instead.',
-            fn (Builder $builder) => $builder->where('name', 'regexp', '/^acme$/'),
-        ];
-
-        yield 'where ilike not supported' => [
-            \LogicException::class,
-            'Operator "ilike" is not supported. Use "like" instead.',
-            fn (Builder $builder) => $builder->where('name', 'ilike', 'acme'),
+            'Missing expected ending delimiter "/" in regular expression "/foo#bar"',
+            fn (Builder $builder) => $builder->where('name', 'regex', '/foo#bar'),
         ];
     }
 

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -601,12 +601,12 @@ class BuilderTest extends TestCase
 
         yield 'where like %' => [
             ['find' => [['name' => new Regex('^.*ac.*me.*$', 'i')], []]],
-            fn (Builder $builder) => $builder->where('name', 'like', '%ac%me%'),
+            fn (Builder $builder) => $builder->where('name', 'like', '%ac%%me%'),
         ];
 
         yield 'where like _' => [
-            ['find' => [['name' => new Regex('^.ac.me.$', 'i')], []]],
-            fn (Builder $builder) => $builder->where('name', 'like', '_ac_me_'),
+            ['find' => [['name' => new Regex('^.ac..me.$', 'i')], []]],
+            fn (Builder $builder) => $builder->where('name', 'like', '_ac__me_'),
         ];
 
         $regex = new Regex('^acme$', 'si');

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -70,6 +70,21 @@ class QueryTest extends TestCase
         $this->assertCount(2, $users);
     }
 
+    public function testRegexp(): void
+    {
+        User::create(['name' => 'Simple', 'company' => 'acme']);
+        User::create(['name' => 'With slash', 'company' => 'oth/er']);
+
+        $users = User::where('company', 'regexp', '/^acme$/')->get();
+        $this->assertCount(1, $users);
+
+        $users = User::where('company', 'regexp', '/^ACME$/i')->get();
+        $this->assertCount(1, $users);
+
+        $users = User::where('company', 'regexp', '/^oth\/er$/')->get();
+        $this->assertCount(1, $users);
+    }
+
     public function testLike(): void
     {
         $users = User::where('name', 'like', '%doe')->get();
@@ -82,6 +97,12 @@ class QueryTest extends TestCase
         $this->assertCount(3, $users);
 
         $users = User::where('name', 'like', 't%')->get();
+        $this->assertCount(1, $users);
+
+        $users = User::where('name', 'like', 'j___ doe')->get();
+        $this->assertCount(2, $users);
+
+        $users = User::where('name', 'like', '_oh_ _o_')->get();
         $this->assertCount(1, $users);
     }
 


### PR DESCRIPTION
Fix [PHPORM-53](https://jira.mongodb.org/browse/PHPORM-53)

- Fix support for `%` and `_` in `like` expression and escaped `\%` and `\_`
- Keep `ilike` and `regexp` operators as aliases for `like` and `regex`
- Allow `/`, `#` and `~` as regex delimiters
- Add functional tests on `regexp` and `not regexp`
- Add support for `not regex`
