### PR TITLE
PHPORM-50 PHPORM-65 Remove call to deprecated `Collection::count` for `countDocuments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Throw an exception when `Query\Builder::orderBy()` is used with invalid direction [#7](https://github.com/GromNaN/laravel-mongodb-private/pull/7) by [@GromNaN](https://github.com/GromNaN).
 - Throw an exception when `Query\Builder::push()` is used incorrectly [#5](https://github.com/GromNaN/laravel-mongodb-private/pull/5) by [@GromNaN](https://github.com/GromNaN).
 - Remove public property `Query\Builder::$paginating` [#15](https://github.com/GromNaN/laravel-mongodb-private/pull/15) by [@GromNaN](https://github.com/GromNaN).
+- Remove call to deprecated `Collection::count` for `countDocuments` [#18](https://github.com/GromNaN/laravel-mongodb-private/pull/18) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -266,7 +266,9 @@ class Builder extends BaseBuilder
                     $aggregations = blank($this->aggregate['columns']) ? [] : $this->aggregate['columns'];
 
                     if (in_array('*', $aggregations) && $function == 'count') {
-                        return ['count' => [$wheres, []]];
+                        $options = $this->inheritConnectionOptions();
+
+                        return ['countDocuments' => [$wheres, $options]];
                     } elseif ($function == 'count') {
                         // Translate count into sum.
                         $group['aggregate'] = ['$sum' => 1];
@@ -329,7 +331,7 @@ class Builder extends BaseBuilder
 
             $options = $this->inheritConnectionOptions();
 
-            return ['distinct' => [$column, $wheres ?: [], $options]];
+            return ['distinct' => [$column, $wheres, $options]];
         } // Normal query
         else {
             // Convert select columns to simple projections.
@@ -396,7 +398,7 @@ class Builder extends BaseBuilder
             $this->columns = [];
         }
 
-        $command = $this->toMql($columns);
+        $command = $this->toMql();
         assert(count($command) >= 1, 'At least one method call is required to execute a query');
 
         $result = $this->collection;


### PR DESCRIPTION
Fix [PHPORM-50](https://jira.mongodb.org/browse/PHPORM-50) and [PHPORM-65](https://jira.mongodb.org/browse/PHPORM-65)

- `MongoDB\Collection::count()` is [deprecated](https://www.mongodb.com/docs/php-library/current/reference/method/MongoDBCollection-count/), replaced by `MongoDB\Collection:: countDocuments()` when an accurate result is expected.
- Fix sending `session` and other connection options in `count` call, so that it get the correct result in a transaction.

Suggested by @alcaeus https://github.com/GromNaN/laravel-mongodb-private/pull/4#discussion_r1258055276