### PR TITLE
PHPORM-35 Allow to cast `_id` to `BinaryUUID` or anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Accept operators prefixed by `$` in `Query\Builder::orWhere` [#20](https://github.com/GromNaN/laravel-mongodb-private/pull/20) by [@GromNaN](https://github.com/GromNaN).
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
+- Fix support for casting `_id` or `id` field [#19](https://github.com/GromNaN/laravel-mongodb-private/pull/19) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -66,6 +66,13 @@ abstract class Model extends BaseModel
             $value = $this->attributes['_id'];
         }
 
+        // If a cast is defined for "id" or "_id", convert the value using it.
+        foreach (['id', '_id'] as $key) {
+            if ($this->hasCast($key)) {
+                return $this->castAttribute($key, $value);
+            }
+        }
+
         // Convert ObjectID to string.
         if ($value instanceof ObjectID) {
             return (string) $value;

--- a/tests/Casts/BinaryUuidTest.php
+++ b/tests/Casts/BinaryUuidTest.php
@@ -5,6 +5,7 @@ namespace Jenssegers\Mongodb\Tests\Casts;
 use Generator;
 use function hex2bin;
 use Jenssegers\Mongodb\Tests\Models\CastBinaryUuid;
+use Jenssegers\Mongodb\Tests\Models\IdCastBinaryUuid;
 use Jenssegers\Mongodb\Tests\TestCase;
 use MongoDB\BSON\Binary;
 
@@ -15,6 +16,7 @@ class BinaryUuidTest extends TestCase
         parent::setUp();
 
         CastBinaryUuid::truncate();
+        IdCastBinaryUuid::truncate();
     }
 
     /** @dataProvider provideBinaryUuidCast */
@@ -25,6 +27,17 @@ class BinaryUuidTest extends TestCase
         $model = CastBinaryUuid::firstWhere('uuid', $queryUuid);
         $this->assertNotNull($model);
         $this->assertSame($expectedUuid, $model->uuid);
+    }
+
+    /** @dataProvider provideBinaryUuidCast */
+    public function testBinaryUuidCastId(string $expectedUuid, string|Binary $saveUuid, Binary $queryUuid): void
+    {
+        IdCastBinaryUuid::create(['_id' => $saveUuid]);
+
+        $model = IdCastBinaryUuid::firstWhere('_id', $queryUuid);
+        $this->assertNotNull($model);
+        $this->assertSame($expectedUuid, $model->_id);
+        $this->assertSame($expectedUuid, $model->id);
     }
 
     public static function provideBinaryUuidCast(): Generator

--- a/tests/Models/IdCastBinaryUuid.php
+++ b/tests/Models/IdCastBinaryUuid.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jenssegers\Mongodb\Tests\Models;
+
+use Jenssegers\Mongodb\Eloquent\Casts\BinaryUuid;
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class IdCastBinaryUuid extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+    protected $casts = [
+        '_id' => BinaryUuid::class,
+    ];
+}


### PR DESCRIPTION
Fix [PHPORM-35](https://jira.mongodb.org/browse/PHPORM-35)

The cast on `_id` field (or its alias `id`) was ignored because of the `getIdAttribute` accessor that is [called before cast](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L2093-L2107) in Eloquent.

@alcaeus you opened the Jira issue, I'm not sure if that covers it.

