### PR TITLE
PHPORM-67 Accept operators prefixed by `$` in `Query\Builder::orWhere`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Throw an exception when `Query\Builder::push()` is used incorrectly [#5](https://github.com/GromNaN/laravel-mongodb-private/pull/5) by [@GromNaN](https://github.com/GromNaN).
 - Remove public property `Query\Builder::$paginating` [#15](https://github.com/GromNaN/laravel-mongodb-private/pull/15) by [@GromNaN](https://github.com/GromNaN).
 - Remove call to deprecated `Collection::count` for `countDocuments` [#18](https://github.com/GromNaN/laravel-mongodb-private/pull/18) by [@GromNaN](https://github.com/GromNaN).
+- Accept operators prefixed by `$` in `Query\Builder::orWhere` [#20](https://github.com/GromNaN/laravel-mongodb-private/pull/20) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -917,10 +917,10 @@ class Builder extends BaseBuilder
         $params = func_get_args();
 
         // Remove the leading $ from operators.
-        if (func_num_args() == 3) {
+        if (func_num_args() >= 3) {
             $operator = &$params[1];
 
-            if (Str::startsWith($operator, '$')) {
+            if (is_string($operator) && str_starts_with($operator, '$')) {
                 $operator = substr($operator, 1);
             }
         }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -76,6 +76,19 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->limit(10)->offset(5)->select('foo', 'bar'),
         ];
 
+        yield 'where accepts $ in operators' => [
+            ['find' => [
+                ['$or' => [
+                    ['foo' => ['$type' => 2]],
+                    ['foo' => ['$type' => 4]],
+                ]],
+                [], // options
+            ]],
+            fn (Builder $builder) => $builder
+                ->where('foo', '$type', 2)
+                ->orWhere('foo', '$type', 4),
+        ];
+
         /** @see DatabaseQueryBuilderTest::testBasicWhereNot() */
         yield 'whereNot (multiple)' => [
             ['find' => [


### PR DESCRIPTION
Fix [PHPORM-67](https://jira.mongodb.org/browse/PHPORM-67)

Issue found by @alcaeus https://github.com/GromNaN/laravel-mongodb/pull/14/files#r1273137525
 