### PR TITLE
PHPORM-68 Fix unique validator when the validated value is part of an existing value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Remove call to deprecated `Collection::count` for `countDocuments` [#18](https://github.com/GromNaN/laravel-mongodb-private/pull/18) by [@GromNaN](https://github.com/GromNaN).
 - Accept operators prefixed by `$` in `Query\Builder::orWhere` [#20](https://github.com/GromNaN/laravel-mongodb-private/pull/20) by [@GromNaN](https://github.com/GromNaN).
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
+- Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Validation/DatabasePresenceVerifier.php
+++ b/src/Validation/DatabasePresenceVerifier.php
@@ -2,6 +2,8 @@
 
 namespace Jenssegers\Mongodb\Validation;
 
+use MongoDB\BSON\Regex;
+
 class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVerifier
 {
     /**
@@ -17,7 +19,7 @@ class DatabasePresenceVerifier extends \Illuminate\Validation\DatabasePresenceVe
      */
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
     {
-        $query = $this->table($collection)->where($column, 'regex', '/'.preg_quote($value).'/i');
+        $query = $this->table($collection)->where($column, new Regex('^'.preg_quote($value).'$', '/i'));
 
         if ($excludeId !== null && $excludeId != 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -48,6 +48,12 @@ class ValidationTest extends TestCase
         );
         $this->assertFalse($validator->fails());
 
+        $validator = Validator::make(
+            ['name' => 'John'], // Part of an existing value
+            ['name' => 'required|unique:users']
+        );
+        $this->assertFalse($validator->fails());
+
         User::create(['name' => 'Johnny Cash', 'email' => 'johnny.cash+200@gmail.com']);
 
         $validator = Validator::make(


### PR DESCRIPTION
Fix [PHPORM-68](https://jira.mongodb.org/browse/PHPORM-68)

- Fix a bug when the validated `John` is a part of a value `John Doe` existing in the collection, by adding start `^` and end `$` matchers
- Use `MongoDB\BSON\Regex` directly to avoid regex parsing (see https://github.com/GromNaN/laravel-mongodb/pull/17)