### PR TITLE
PHPORM-35 Add various tests on Model `_id` types

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -332,7 +332,7 @@ class ModelTest extends TestCase
     /**
      * @dataProvider provideId
      */
-    public function testPrimaryKey(string $model, $id, $expected): void
+    public function testPrimaryKey(string $model, $id, $expected, bool $expectedFound): void
     {
         $model::truncate();
         $expectedType = get_debug_type($expected);
@@ -349,78 +349,78 @@ class ModelTest extends TestCase
 
         $check = $model::find($id);
 
-        $this->assertNotNull($check, 'Not found');
-        $this->assertSame($expectedType, get_debug_type($check->_id));
-        $this->assertEquals($id, $check->_id);
-        $this->assertSame($expectedType, get_debug_type($check->getKey()));
-        $this->assertEquals($id, $check->getKey());
+        if ($expectedFound) {
+            $this->assertNotNull($check, 'Not found');
+            $this->assertSame($expectedType, get_debug_type($check->_id));
+            $this->assertEquals($id, $check->_id);
+            $this->assertSame($expectedType, get_debug_type($check->getKey()));
+            $this->assertEquals($id, $check->getKey());
+        } else {
+            $this->assertNull($check, 'Found');
+        }
     }
 
     public static function provideId(): iterable
     {
         yield 'int' => [
-            User::class,
-            10,
-            10,
+            'model' => User::class,
+            'id' => 10,
+            'expected' => 10,
+            // Don't expect this to be found, as the int is cast to string for the query
+            'expectedFound' => false,
         ];
 
         yield 'cast as int' => [
-            IdIsInt::class,
-            10,
-            10,
+            'model' => IdIsInt::class,
+            'id' => 10,
+            'expected' => 10,
+            'expectedFound' => true,
         ];
 
         yield 'string' => [
-            User::class,
-            'user-10',
-            'user-10',
+            'model' => User::class,
+            'id' => 'user-10',
+            'expected' => 'user-10',
+            'expectedFound' => true,
         ];
 
         yield 'cast as string' => [
-            IdIsString::class,
-            'user-10',
-            'user-10',
+            'model' => IdIsString::class,
+            'id' => 'user-10',
+            'expected' => 'user-10',
+            'expectedFound' => true,
         ];
 
         $objectId = new ObjectID();
         yield 'ObjectID' => [
-            User::class,
-            $objectId,
-            (string) $objectId,
+            'model' => User::class,
+            'id' => $objectId,
+            'expected' => (string) $objectId,
+            'expectedFound' => true,
         ];
 
         $binaryUuid = new Binary(hex2bin('0c103357380648c9a84b867dcb625cfb'), Binary::TYPE_UUID);
         yield 'BinaryUuid' => [
-            User::class,
-            $binaryUuid,
-            (string) $binaryUuid,
+            'model' => User::class,
+            'id' => $binaryUuid,
+            'expected' => (string) $binaryUuid,
+            'expectedFound' => true,
         ];
 
         yield 'cast as BinaryUuid' => [
-            IdIsBinaryUuid::class,
-            $binaryUuid,
-            (string) $binaryUuid,
+            'model' => IdIsBinaryUuid::class,
+            'id' => $binaryUuid,
+            'expected' => (string) $binaryUuid,
+            'expectedFound' => true,
         ];
 
         $date = new UTCDateTime();
         yield 'UTCDateTime' => [
-            User::class,
-            $date,
-            $date,
-        ];
-
-        $array = ['foo' => 'bar'];
-        yield 'array' => [
-            User::class,
-            $array,
-            $array,
-        ];
-
-        $object = (object) ['foo' => 'bar'];
-        yield 'object' => [
-            User::class,
-            $object,
-            $object,
+            'model' => User::class,
+            'id' => $date,
+            'expected' => $date,
+            // Don't expect this to be found, as the original value is stored as UTCDateTime but then cast to string
+            'expectedFound' => false,
         ];
     }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -408,6 +408,20 @@ class ModelTest extends TestCase
             $date,
             $date,
         ];
+
+        $array = ['foo' => 'bar'];
+        yield 'array' => [
+            User::class,
+            $array,
+            $array,
+        ];
+
+        $object = (object) ['foo' => 'bar'];
+        yield 'object' => [
+            User::class,
+            $object,
+            $object,
+        ];
     }
 
     public function testCustomPrimaryKey(): void

--- a/tests/Models/IdIsBinaryUuid.php
+++ b/tests/Models/IdIsBinaryUuid.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jenssegers\Mongodb\Tests\Models;
+
+use Jenssegers\Mongodb\Eloquent\Casts\BinaryUuid;
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class IdIsBinaryUuid extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+    protected $casts = [
+        '_id' => BinaryUuid::class,
+    ];
+}

--- a/tests/Models/IdIsInt.php
+++ b/tests/Models/IdIsInt.php
@@ -8,6 +8,7 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
 
 class IdIsInt extends Eloquent
 {
+    protected $keyType = 'int';
     protected $connection = 'mongodb';
     protected static $unguarded = true;
     protected $casts = [

--- a/tests/Models/IdIsInt.php
+++ b/tests/Models/IdIsInt.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jenssegers\Mongodb\Tests\Models;
+
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class IdIsInt extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+    protected $casts = [
+        '_id' => 'int',
+    ];
+}

--- a/tests/Models/IdIsString.php
+++ b/tests/Models/IdIsString.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jenssegers\Mongodb\Tests\Models;
+
+use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
+
+class IdIsString extends Eloquent
+{
+    protected $connection = 'mongodb';
+    protected static $unguarded = true;
+    protected $casts = [
+        '_id' => 'string',
+    ];
+}


### PR DESCRIPTION
Fix [PHPORM-35](https://jira.mongodb.org/browse/PHPORM-35)

Adding tests on _id with various types.

`int` and `UTCDateTime` are not supported for query because the value is automatically converted to `string` by [`Laravel\Database\Eloquent\Builder`](https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Builder.php#L248-L250).