### PR TITLE
PHPORM-8 Remove automatic _id conversion, apply Cast to queries

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -241,4 +241,9 @@ class Builder extends EloquentBuilder
             ];
         })->values();
     }
+
+    public function whereKey($id)
+    {
+        return parent::whereKey($this->model->convertKey($id));
+    }
 }

--- a/src/Eloquent/Casts/ObjectId.php
+++ b/src/Eloquent/Casts/ObjectId.php
@@ -5,11 +5,19 @@ namespace Jenssegers\Mongodb\Eloquent\Casts;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Jenssegers\Mongodb\Eloquent\Model;
 use MongoDB\BSON\ObjectId as BSONObjectId;
+use MongoDB\Driver\Exception\InvalidArgumentException;
 
+/**
+ * Store the value as an ObjectId in the database. This cast should be used for _id fields.
+ * The value read from the database will not be transformed.
+ *
+ * @extends CastsAttributes<BSONObjectId, BSONObjectId>
+ */
 class ObjectId implements CastsAttributes
 {
     /**
      * Cast the given value.
+     * Nothing will be done here, the value should already be an ObjectId in the database.
      *
      * @param  Model  $model
      * @param  string  $key
@@ -19,25 +27,37 @@ class ObjectId implements CastsAttributes
      */
     public function get($model, string $key, $value, array $attributes)
     {
-        if (! $value instanceof BSONObjectId) {
-            return $value;
+        if ($value instanceof BSONObjectId && $model->getKeyName() === $key && $model->getKeyType() === 'string') {
+            return (string) $value;
         }
 
-        return (string) $value;
+        return $value;
     }
 
     /**
      * Prepare the given value for storage.
+     * The value will be converted to an ObjectId.
      *
      * @param  Model  $model
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $attributes
      * @return mixed
+     *
+     * @throws \RuntimeException when the value is not an ObjectID or a valid ID string.
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        $value = $value instanceof BSONObjectId ? $value : new BSONObjectId($value);
+        if (! $value instanceof BSONObjectId) {
+            if (! is_string($value)) {
+                throw new \RuntimeException(sprintf('Invalid BSON ObjectID provided for %s[%s]. "string" or %s expected, got "%s". Remove the ObjectId cast if you need to store other types of values.', get_class($model), $key, BSONObjectId::class, get_debug_type($value)));
+            }
+            try {
+                $value = new BSONObjectId($value);
+            } catch (InvalidArgumentException $e) {
+                throw new \RuntimeException(sprintf('Invalid BSON ObjectID provided for %s[%s]: %s. Remove the ObjectID cast if you need to store string values.', get_class($model), $key, $value), 0, $e);
+            }
+        }
 
         return [$key => $value];
     }

--- a/src/Eloquent/Casts/ObjectId.php
+++ b/src/Eloquent/Casts/ObjectId.php
@@ -37,10 +37,8 @@ class ObjectId implements CastsAttributes
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        if ($value instanceof BSONObjectId) {
-            return $value;
-        }
+        $value = $value instanceof BSONObjectId ? $value : new BSONObjectId($value);
 
-        return new BSONObjectId($value);
+        return [$key => $value];
     }
 }

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -2,6 +2,7 @@
 
 namespace Jenssegers\Mongodb\Eloquent;
 
+use MongoDB\BSON\ObjectId;
 use function array_key_exists;
 use DateTimeInterface;
 use function explode;
@@ -41,7 +42,7 @@ abstract class Model extends BaseModel
      *
      * @var string
      */
-    protected $keyType = 'string';
+    protected $keyType = ObjectId::class;
 
     /**
      * The parent relation instance.

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -188,7 +188,7 @@ class Builder extends BaseBuilder
      */
     public function find($id, $columns = [])
     {
-        return $this->where('_id', '=', $this->convertKey($id))->first($columns);
+        return parent::find($id, $columns);
     }
 
     /**
@@ -885,25 +885,6 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Convert a key to ObjectID if needed.
-     *
-     * @param  mixed  $id
-     * @return mixed
-     */
-    public function convertKey($id)
-    {
-        if (is_string($id) && strlen($id) === 24 && ctype_xdigit($id)) {
-            return new ObjectID($id);
-        }
-
-        if (is_string($id) && strlen($id) === 16 && preg_match('~[^\x20-\x7E\t\r\n]~', $id) > 0) {
-            return new Binary($id, Binary::TYPE_UUID);
-        }
-
-        return $id;
-    }
-
-    /**
      * @inheritdoc
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
@@ -947,19 +928,6 @@ class Builder extends BaseBuilder
                 // Convert aliased operators
                 if (isset($this->conversion[$where['operator']])) {
                     $where['operator'] = $this->conversion[$where['operator']];
-                }
-            }
-
-            // Convert id's.
-            if (isset($where['column']) && ($where['column'] == '_id' || Str::endsWith($where['column'], '._id'))) {
-                // Multiple values.
-                if (isset($where['values'])) {
-                    foreach ($where['values'] as &$value) {
-                        $value = $this->convertKey($value);
-                    }
-                } // Single value.
-                elseif (isset($where['value'])) {
-                    $where['value'] = $this->convertKey($where['value']);
                 }
             }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -872,7 +872,7 @@ class Builder extends BaseBuilder
         $wheres = $this->compileWheres();
         $result = $this->collection->updateMany($wheres, $query, $options);
         if (1 == (int) $result->isAcknowledged()) {
-            return $result->getModifiedCount() ? $result->getModifiedCount() : $result->getUpsertedCount();
+            return $result->getModifiedCount() ?: $result->getUpsertedCount();
         }
 
         return 0;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -12,8 +12,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Jenssegers\Mongodb\Connection;
-use MongoDB\BSON\Binary;
-use MongoDB\BSON\ObjectID;
 use MongoDB\BSON\Regex;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Cursor;
@@ -188,7 +186,7 @@ class Builder extends BaseBuilder
      */
     public function find($id, $columns = [])
     {
-        return parent::find($id, $columns);
+        return $this->where('_id', '=', $id)->first($columns);
     }
 
     /**
@@ -660,14 +658,6 @@ class Builder extends BaseBuilder
     /**
      * @inheritdoc
      */
-    public function chunkById($count, callable $callback, $column = '_id', $alias = null)
-    {
-        return parent::chunkById($count, $callback, $column, $alias);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = '_id')
     {
         return parent::forPageAfterId($perPage, $lastId, $column);
@@ -905,6 +895,11 @@ class Builder extends BaseBuilder
         }
 
         return parent::where(...$params);
+    }
+
+    protected function defaultKeyName(): string
+    {
+        return '_id';
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -186,7 +186,11 @@ class Builder extends BaseBuilder
      */
     public function find($id, $columns = [])
     {
-        return $this->where('_id', '=', $id)->first($columns);
+        /**
+         * Remove this method when this is fixed in Laravel.
+         * @see https://github.com/laravel/framework/pull/48089
+         */
+        return $this->where($this->defaultKeyName(), '=', $id)->first($columns);
     }
 
     /**

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -325,7 +325,7 @@ class BelongsToMany extends EloquentBelongsToMany
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }
-            $results[$id] = $attributes;
+            $results[(string) $id] = $attributes;
         }
 
         return $results;

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -195,14 +195,14 @@ class BelongsToMany extends EloquentBelongsToMany
 
             $query = $this->newRelatedQuery();
 
-            $query->whereIn($this->related->getKeyName(), (array) $id);
+            $query->whereIn($this->related->getKeyName(), is_array($id) ? $id : [$id]);
 
             // Attach the new parent id to the related model.
             $query->push($this->foreignPivotKey, $this->parent->getKey(), true);
         }
 
         // Attach the new ids to the parent model.
-        $this->parent->push($this->getRelatedKey(), (array) $id, true);
+        $this->parent->push($this->getRelatedKey(), is_array($id) ? $id : [$id], true);
 
         if ($touch) {
             $this->touchIfTouching();
@@ -215,7 +215,7 @@ class BelongsToMany extends EloquentBelongsToMany
     public function detach($ids = [], $touch = true)
     {
         if ($ids instanceof Model) {
-            $ids = (array) $ids->getKey();
+            $ids = $ids->getKey();
         }
 
         $query = $this->newRelatedQuery();
@@ -223,7 +223,9 @@ class BelongsToMany extends EloquentBelongsToMany
         // If associated IDs were passed to the method we will only delete those
         // associations, otherwise all of the association ties will be broken.
         // We'll return the numbers of affected rows when we do the deletes.
-        $ids = (array) $ids;
+        if (! is_array($ids)) {
+            $ids = [$ids];
+        }
 
         // Detach all ids from the parent model.
         $this->parent->pull($this->getRelatedKey(), $ids);
@@ -257,7 +259,7 @@ class BelongsToMany extends EloquentBelongsToMany
 
         foreach ($results as $result) {
             foreach ($result->$foreign as $item) {
-                $dictionary[$item][] = $result;
+                $dictionary[(string) $item][] = $result;
             }
         }
 

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -212,9 +212,15 @@ abstract class EmbedsOneOrMany extends Relation
         $attributes = $this->parent->getAttributes();
 
         // Get embedded models form parent attributes.
-        $embedded = isset($attributes[$this->localKey]) ? (array) $attributes[$this->localKey] : null;
+        if (!isset($attributes[$this->localKey])) {
+            return null;
+        }
 
-        return $embedded;
+        if (is_array($attributes[$this->localKey])) {
+            return $attributes[$this->localKey];
+        }
+
+        return [$attributes[$this->localKey]];
     }
 
     /**

--- a/src/Relations/EmbedsOneOrMany.php
+++ b/src/Relations/EmbedsOneOrMany.php
@@ -245,8 +245,7 @@ abstract class EmbedsOneOrMany extends Relation
             $id = $id->getKey();
         }
 
-        // Convert the id to MongoId if necessary.
-        return $this->toBase()->convertKey($id);
+        return $id;
     }
 
     /**

--- a/tests/EmbeddedRelationsTest.php
+++ b/tests/EmbeddedRelationsTest.php
@@ -60,7 +60,7 @@ class EmbeddedRelationsTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $address->created_at);
         $this->assertInstanceOf(DateTime::class, $address->updated_at);
         $this->assertNotNull($address->_id);
-        $this->assertIsString($address->_id);
+        $this->assertInstanceOf(ObjectId::class, $address->_id);
 
         $raw = $address->getAttributes();
         $this->assertInstanceOf(ObjectId::class, $raw['_id']);
@@ -183,7 +183,7 @@ class EmbeddedRelationsTest extends TestCase
         $user = User::create([]);
         $address = $user->addresses()->create(['city' => 'Bruxelles']);
         $this->assertInstanceOf(Address::class, $address);
-        $this->assertIsString($address->_id);
+        $this->assertInstanceOf(ObjectId::class, $address->_id);
         $this->assertEquals(['Bruxelles'], $user->addresses->pluck('city')->all());
 
         $raw = $address->getAttributes();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -86,6 +86,7 @@ class ModelTest extends TestCase
 
         /** @var User $check */
         $check = User::find($user->_id);
+        $this->assertInstanceOf(User::class, $check);
         $check->age = 36;
         $check->save();
 
@@ -395,22 +396,24 @@ class ModelTest extends TestCase
         yield 'ObjectID' => [
             'model' => User::class,
             'id' => $objectId,
-            'expected' => (string) $objectId,
-            'expectedFound' => true,
+            'expected' => $objectId,
+            // Not found as the keyType is "string"
+            'expectedFound' => false,
         ];
 
         $binaryUuid = new Binary(hex2bin('0c103357380648c9a84b867dcb625cfb'), Binary::TYPE_UUID);
         yield 'BinaryUuid' => [
             'model' => User::class,
             'id' => $binaryUuid,
-            'expected' => (string) $binaryUuid,
-            'expectedFound' => true,
+            'expected' => $binaryUuid,
+            // Not found as the keyType is "string"
+            'expectedFound' => false,
         ];
 
         yield 'cast as BinaryUuid' => [
             'model' => IdIsBinaryUuid::class,
             'id' => $binaryUuid,
-            'expected' => (string) $binaryUuid,
+            'expected' => $binaryUuid,
             'expectedFound' => true,
         ];
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -62,8 +62,8 @@ class ModelTest extends TestCase
 
         $this->assertTrue(isset($user->_id));
         $this->assertIsString($user->_id);
-        $this->assertNotEquals('', (string) $user->_id);
-        $this->assertNotEquals(0, strlen((string) $user->_id));
+        $this->assertNotEquals('', $user->_id);
+        $this->assertNotEquals(0, strlen($user->_id));
         $this->assertInstanceOf(Carbon::class, $user->created_at);
 
         $raw = $user->getAttributes();
@@ -123,14 +123,14 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(ObjectID::class, $raw['_id']);
 
         $user = new User;
-        $user->_id = 'customId';
+        $user->_id = '64d9e303455918c12204cfb5';
         $user->name = 'John Doe';
         $user->title = 'admin';
         $user->age = 35;
         $user->save();
 
         $this->assertTrue($user->exists);
-        $this->assertEquals('customId', $user->_id);
+        $this->assertEquals('64d9e303455918c12204cfb5', $user->_id);
 
         $raw = $user->getAttributes();
         $this->assertIsString($raw['_id']);
@@ -275,7 +275,8 @@ class ModelTest extends TestCase
         $user->age = 35;
         $user->save();
 
-        User::destroy((string) $user->_id);
+        $this->assertIsString($user->_id);
+        User::destroy($user->_id);
 
         $this->assertEquals(0, User::count());
     }
@@ -396,9 +397,9 @@ class ModelTest extends TestCase
         yield 'ObjectID' => [
             'model' => User::class,
             'id' => $objectId,
-            'expected' => $objectId,
-            // Not found as the keyType is "string"
-            'expectedFound' => false,
+            // $keyType is string, so the ObjectID caster convert to string
+            'expected' => (string) $objectId,
+            'expectedFound' => true,
         ];
 
         $binaryUuid = new Binary(hex2bin('0c103357380648c9a84b867dcb625cfb'), Binary::TYPE_UUID);
@@ -466,7 +467,7 @@ class ModelTest extends TestCase
         $this->assertEquals(['_id', 'created_at', 'name', 'type', 'updated_at'], $keys);
         $this->assertIsString($array['created_at']);
         $this->assertIsString($array['updated_at']);
-        $this->assertIsString($array['_id']);
+        $this->assertInstanceOf(ObjectID::class, $array['_id']);
     }
 
     public function testUnset(): void
@@ -719,20 +720,20 @@ class ModelTest extends TestCase
         $user->push('tags', 'tag2', true);
 
         $this->assertEquals(['tag1', 'tag1', 'tag2'], $user->tags);
-        $user = User::where('_id', $user->_id)->first();
+        $user = User::find($user->_id);
         $this->assertEquals(['tag1', 'tag1', 'tag2'], $user->tags);
 
         $user->pull('tags', 'tag1');
 
         $this->assertEquals(['tag2'], $user->tags);
-        $user = User::where('_id', $user->_id)->first();
+        $user = User::find($user->_id)->first();
         $this->assertEquals(['tag2'], $user->tags);
 
         $user->push('tags', 'tag3');
         $user->pull('tags', ['tag2', 'tag3']);
 
         $this->assertEquals([], $user->tags);
-        $user = User::where('_id', $user->_id)->first();
+        $user = User::find($user->_id)->first();
         $this->assertEquals([], $user->tags);
     }
 

--- a/tests/Models/Address.php
+++ b/tests/Models/Address.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace Jenssegers\Mongodb\Tests\Models;
 
+use Jenssegers\Mongodb\Eloquent\Casts\ObjectId as ObjectIdCast;
 use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
 use Jenssegers\Mongodb\Relations\EmbedsMany;
+use MongoDB\BSON\ObjectId;
 
 class Address extends Eloquent
 {
     protected $connection = 'mongodb';
     protected static $unguarded = true;
+    protected $keyType = ObjectId::class;
+
+    protected $casts = [
+        '_id' => ObjectIdCast::class,
+    ];
 
     public function addresses(): EmbedsMany
     {

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
+use Jenssegers\Mongodb\Eloquent\Casts\ObjectId as ObjectIdCast;
 use Jenssegers\Mongodb\Eloquent\HybridRelations;
 use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
 
@@ -38,6 +39,7 @@ class User extends Eloquent implements AuthenticatableContract, CanResetPassword
 
     protected $connection = 'mongodb';
     protected $casts = [
+        '_id' => ObjectIdCast::class,
         'birthday' => 'datetime',
         'entry.date' => 'datetime',
         'member_status' => MemberStatus::class,

--- a/tests/RelationsTest.php
+++ b/tests/RelationsTest.php
@@ -217,8 +217,8 @@ class RelationsTest extends TestCase
         $client = Client::Where('name', '=', 'Buffet Bar Inc.')->first();
 
         // Assert they are attached
-        $this->assertContains($client->_id, $user->client_ids);
-        $this->assertContains($user->_id, $client->user_ids);
+        $this->assertContainsObjectId($client->_id, $user->client_ids);
+        $this->assertContainsObjectId($user->_id, $client->user_ids);
         $this->assertCount(2, $user->clients);
         $this->assertCount(2, $client->users);
 
@@ -348,8 +348,8 @@ class RelationsTest extends TestCase
         $this->assertArrayHasKey('groups', $user->getAttributes());
 
         // Assert they are attached
-        $this->assertContains($group->_id, $user->groups->pluck('_id')->toArray());
-        $this->assertContains($user->_id, $group->users->pluck('_id')->toArray());
+        $this->assertContainsObjectId($group->_id, $user->groups->pluck('_id')->toArray());
+        $this->assertContainsObjectId($user->_id, $group->users->pluck('_id')->toArray());
         $this->assertEquals($group->_id, $user->groups()->first()->_id);
         $this->assertEquals($user->_id, $group->users()->first()->_id);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,10 +11,25 @@ use Jenssegers\Mongodb\MongodbQueueServiceProvider;
 use Jenssegers\Mongodb\MongodbServiceProvider;
 use Jenssegers\Mongodb\Tests\Models\User;
 use Jenssegers\Mongodb\Validation\ValidationServiceProvider;
+use MongoDB\BSON\ObjectId;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 class TestCase extends OrchestraTestCase
 {
+    public static function assertContainsObjectId(ObjectId $expectedObjectId, array $objectIds, string $message = ''): void
+    {
+        self::assertNotEmpty($objectIds, $message ?: 'Failed asserting that array of object ids is not empty.');
+
+        foreach ($objectIds as $objectId) {
+            if ($objectId == $expectedObjectId) {
+                // Found successfully
+                return;
+            }
+        }
+
+        self::fail($message ?: sprintf('Failed asserting that ObjectId(%s) was found in [ObjectId(%s)].', $expectedObjectId, implode('), ObjectId(', $objectIds).')'));
+    }
+
     /**
      * Get application providers.
      *


### PR DESCRIPTION
Developers should work with `ObjectId` for the `_id` field.

But if the `Model::$keyType` is `string`, they can use a cast to convert database values (`ObjectId`) to `string` when reading, and `string` to `ObjectId` when setting the value for the database (as document value or for a query).

Changes are TDD: I updated to code to make the tests work as much as possible.

Only the model key is casted because this where there is an issue. But could opt for a more generic approach an apply the cast to all the values sent to Eloquent builder (ie: linked to a model).