### PR TITLE
Remove `Query\Builder::__constructor` overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
 - Support `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
+- Change signature of `Query\Builder::__constructor` to match the parent class [#26](https://github.com/GromNaN/laravel-mongodb-private/pull/26) by [@GromNaN](https://github.com/GromNaN).
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -74,7 +74,7 @@ class Connection extends BaseConnection
      */
     public function collection($collection)
     {
-        $query = new Query\Builder($this, $this->getPostProcessor());
+        $query = new Query\Builder($this, $this->getQueryGrammar(), $this->getPostProcessor());
 
         return $query->from($collection);
     }

--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -164,10 +164,10 @@ class Builder extends EloquentBuilder
     /**
      * @inheritdoc
      */
-    public function raw($expression = null)
+    public function raw($value = null)
     {
         // Get raw results from the query builder.
-        $results = $this->query->raw($expression);
+        $results = $this->query->raw($value);
 
         // Convert MongoCursor results to a collection of models.
         if ($results instanceof Cursor) {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -433,7 +433,7 @@ abstract class Model extends BaseModel
     {
         $connection = $this->getConnection();
 
-        return new QueryBuilder($connection, $connection->getPostProcessor());
+        return new QueryBuilder($connection, $connection->getQueryGrammar(), $connection->getPostProcessor());
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -135,16 +135,6 @@ class Builder extends BaseBuilder
     ];
 
     /**
-     * @inheritdoc
-     */
-    public function __construct(Connection $connection, Processor $processor)
-    {
-        $this->grammar = new Grammar;
-        $this->connection = $connection;
-        $this->processor = $processor;
-    }
-
-    /**
      * Set the projections.
      *
      * @param  array  $columns
@@ -758,16 +748,16 @@ class Builder extends BaseBuilder
     /**
      * @inheritdoc
      */
-    public function raw($expression = null)
+    public function raw($value = null)
     {
         // Execute the closure on the mongodb collection
-        if ($expression instanceof Closure) {
-            return call_user_func($expression, $this->collection);
+        if ($value instanceof Closure) {
+            return call_user_func($value, $this->collection);
         }
 
         // Create an expression for the given value
-        if ($expression !== null) {
-            return new Expression($expression);
+        if ($value !== null) {
+            return new Expression($value);
         }
 
         // Quick access to the mongodb collection
@@ -856,7 +846,7 @@ class Builder extends BaseBuilder
      */
     public function newQuery()
     {
-        return new self($this->connection, $this->processor);
+        return new self($this->connection, null, $this->processor);
     }
 
     /**

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Tests\Database\DatabaseQueryBuilderTest;
 use Jenssegers\Mongodb\Connection;
 use Jenssegers\Mongodb\Query\Builder;
+use Jenssegers\Mongodb\Query\Grammar;
 use Jenssegers\Mongodb\Query\Processor;
 use Mockery as m;
 use MongoDB\BSON\Regex;
@@ -838,7 +839,8 @@ class BuilderTest extends TestCase
         $connection = m::mock(Connection::class);
         $processor = m::mock(Processor::class);
         $connection->shouldReceive('getSession')->andReturn(null);
+        $connection->shouldReceive('getQueryGrammar')->andReturn(new Grammar());
 
-        return new Builder($connection, $processor);
+        return new Builder($connection, null, $processor);
     }
 }


### PR DESCRIPTION
The constructor don't need to be overloaded to set the default grammar. It is read from the connection by default.

https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Query/Builder.php#L246