### PR TITLE
PHPORM-60 Fix Query on whereDate, whereDay, whereMonth, whereYear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
 - Support `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
+- Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear` to use MongoDB operators [#2376](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu)
 
 ## [3.9.2] - 2022-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 - Remove `Query\Builder::whereAll($column, $values)`. Use `Query\Builder::where($column, 'all', $values)` instead. [#16](https://github.com/GromNaN/laravel-mongodb-private/pull/16) by [@GromNaN](https://github.com/GromNaN).
 - Fix validation of unique values when the validated value is found as part of an existing value. [#21](https://github.com/GromNaN/laravel-mongodb-private/pull/21) by [@GromNaN](https://github.com/GromNaN).
 - Support `%` and `_` in `like` expression [#17](https://github.com/GromNaN/laravel-mongodb-private/pull/17) by [@GromNaN](https://github.com/GromNaN).
-- Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear` to use MongoDB operators [#2376](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu)
+- Fix Query on `whereDate`, `whereDay`, `whereMonth`, `whereYear`, `whereTime` to use MongoDB operators [#2376](https://github.com/jenssegers/laravel-mongodb/pull/2376) by [@Davpyu](https://github.com/Davpyu)
 
 ## [3.9.2] - 2022-09-01
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1191,14 +1191,12 @@ class Builder extends BaseBuilder
      */
     protected function compileWhereDate(array $where): array
     {
-        extract($where);
+        $startOfDay = new UTCDateTime(Carbon::parse($where['value'])->startOfDay());
+        $endOfDay = new UTCDateTime(Carbon::parse($where['value'])->endOfDay());
 
-        $startOfDay = new UTCDateTime(Carbon::parse($value)->startOfDay());
-        $endOfDay = new UTCDateTime(Carbon::parse($value)->endOfDay());
-
-        return match($operator) {
+        return match($where['operator']) {
             'eq', '=' => [
-                $column => [
+                $where['column'] => [
                     '$gte' => $startOfDay,
                     '$lte' => $endOfDay,
                 ],
@@ -1206,25 +1204,25 @@ class Builder extends BaseBuilder
             'ne' => [
                 '$or' => [
                     [
-                        $column => [
+                        $where['column'] => [
                             '$lt' => $startOfDay,
                         ],
                     ],
                     [
-                        $column => [
+                        $where['column'] => [
                             '$gt' => $endOfDay,
                         ],
                     ],
                 ],
             ],
             'lt', 'gte' => [
-                $column => [
-                    '$'.$operator => $startOfDay,
+                $where['column'] => [
+                    '$'.$where['operator'] => $startOfDay,
                 ],
             ],
             'gt', 'lte' => [
-                $column => [
-                    '$'.$operator => $endOfDay,
+                $where['column'] => [
+                    '$'.$where['operator'] => $endOfDay,
                 ],
             ],
         };
@@ -1236,17 +1234,13 @@ class Builder extends BaseBuilder
      */
     protected function compileWhereMonth(array $where): array
     {
-        extract($where);
-
-        $value = (int) ltrim($value, '0');
-
         return [
             '$expr' => [
-                '$'.$operator => [
+                '$'.$where['operator'] => [
                     [
-                        '$month' => '$'.$column,
+                        '$month' => '$'.$where['column'],
                     ],
-                    $value,
+                    (int) $where['value'],
                 ],
             ],
         ];
@@ -1258,17 +1252,13 @@ class Builder extends BaseBuilder
      */
     protected function compileWhereDay(array $where): array
     {
-        extract($where);
-
-        $value = (int) ltrim($value, '0');
-
         return [
             '$expr' => [
-                '$'.$operator => [
+                '$'.$where['operator'] => [
                     [
-                        '$dayOfMonth' => '$'.$column,
+                        '$dayOfMonth' => '$'.$where['column'],
                     ],
-                    $value,
+                    (int) $where['value'],
                 ],
             ],
         ];
@@ -1280,17 +1270,13 @@ class Builder extends BaseBuilder
      */
     protected function compileWhereYear(array $where): array
     {
-        extract($where);
-
-        $value = (int) $value;
-
         return [
             '$expr' => [
-                '$'.$operator => [
+                '$'.$where['operator'] => [
                     [
-                        '$year' => '$'.$column,
+                        '$year' => '$'.$where['column'],
                     ],
-                    $value,
+                    (int) $where['value'],
                 ],
             ],
         ];
@@ -1302,15 +1288,13 @@ class Builder extends BaseBuilder
      */
     protected function compileWhereTime(array $where): array
     {
-        extract($where);
-
         return [
             '$expr' => [
-                '$'.$operator => [
+                '$'.$where['operator'] => [
                     [
-                        '$dateToString' => ['date' => '$'.$column, 'format' => '%H:%M:%S'],
+                        '$dateToString' => ['date' => '$'.$where['column'], 'format' => '%H:%M:%S'],
                     ],
-                    $value,
+                    $where['value'],
                 ],
             ],
         ];

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -117,6 +117,7 @@ class Builder extends BaseBuilder
      * @var array
      */
     protected $conversion = [
+        '=' => 'eq',
         '!=' => 'ne',
         '<>' => 'ne',
         '<' => 'lt',
@@ -1085,7 +1086,7 @@ class Builder extends BaseBuilder
             $operator = $operator === 'regex' ? '=' : 'not';
         }
 
-        if (! isset($operator) || $operator == '=') {
+        if (! isset($operator) || $operator === '=' || $operator === 'eq') {
             $query = [$column => $value];
         } else {
             $query = [$column => ['$'.$operator => $value]];
@@ -1195,39 +1196,27 @@ class Builder extends BaseBuilder
         $startOfDay = new UTCDateTime(Carbon::parse($value)->startOfDay());
         $endOfDay = new UTCDateTime(Carbon::parse($value)->endOfDay());
 
-        $operator = $this->conversion[$operator];
-
         return match($operator) {
-            '=' => [
+            'eq', '=' => [
                 $column => [
                     '$gte' => $startOfDay,
                     '$lte' => $endOfDay,
                 ],
             ],
-            '$ne' => [
+            'ne' => [
                 $column => [
                     '$gt' => $endOfDay,
                     '$lt' => $startOfDay,
                 ],
             ],
-            '$lt' => [
+            'lt', 'gte' => [
                 $column => [
-                    '$lt' => $startOfDay,
+                    '$'.$operator => $startOfDay,
                 ],
             ],
-            '$gt' => [
+            'gt', 'lte' => [
                 $column => [
-                    '$gt' => $endOfDay,
-                ],
-            ],
-            '$lte' => [
-                $column => [
-                    '$lte' => $endOfDay,
-                ],
-            ],
-            '$gte' => [
-                $column => [
-                    '$gte' => $startOfDay,
+                    '$'.$operator => $endOfDay,
                 ],
             ],
         };
@@ -1241,14 +1230,13 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
-        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
+        $value = (int) ltrim($value, '0');
 
         return [
             '$expr' => [
-                $operator => [
+                '$'.$operator => [
                     [
-                        '$month' => '$'.$column
+                        '$month' => '$'.$column,
                     ],
                     $value,
                 ],
@@ -1264,14 +1252,13 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
-        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
+        $value = (int) ltrim($value, '0');
 
         return [
             '$expr' => [
-                $operator => [
+                '$'.$operator => [
                     [
-                        '$dayOfMonth' => '$'.$column
+                        '$dayOfMonth' => '$'.$column,
                     ],
                     $value,
                 ],
@@ -1287,15 +1274,15 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $value = (int) $value;
 
         return [
             '$expr' => [
-                $operator => [
+                '$'.$operator => [
                     [
-                        '$year' => '$'.$column
+                        '$year' => '$'.$column,
                     ],
-                    $value
+                    $value,
                 ],
             ],
         ];

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1304,10 +1304,16 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
-
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                '$'.$operator => [
+                    [
+                        '$dateToString' => ['date' => '$'.$column, 'format' => '%H:%M:%S'],
+                    ],
+                    $value,
+                ],
+            ],
+        ];
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -1204,9 +1204,17 @@ class Builder extends BaseBuilder
                 ],
             ],
             'ne' => [
-                $column => [
-                    '$gt' => $endOfDay,
-                    '$lt' => $startOfDay,
+                '$or' => [
+                    [
+                        $column => [
+                            '$lt' => $startOfDay,
+                        ],
+                    ],
+                    [
+                        $column => [
+                            '$gt' => $endOfDay,
+                        ],
+                    ],
                 ],
             ],
             'lt', 'gte' => [

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
@@ -1191,10 +1192,45 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $startOfDay = new UTCDateTime(Carbon::parse($value)->startOfDay());
+        $endOfDay = new UTCDateTime(Carbon::parse($value)->endOfDay());
 
-        return $this->compileWhereBasic($where);
+        $operator = $this->conversion[$operator];
+
+        return match($operator) {
+            '=' => [
+                $column => [
+                    '$gte' => $startOfDay,
+                    '$lte' => $endOfDay,
+                ],
+            ],
+            '$ne' => [
+                $column => [
+                    '$gt' => $endOfDay,
+                    '$lt' => $startOfDay,
+                ],
+            ],
+            '$lt' => [
+                $column => [
+                    '$lt' => $startOfDay,
+                ],
+            ],
+            '$gt' => [
+                $column => [
+                    '$gt' => $endOfDay,
+                ],
+            ],
+            '$lte' => [
+                $column => [
+                    '$lte' => $endOfDay,
+                ],
+            ],
+            '$gte' => [
+                $column => [
+                    '$gte' => $startOfDay,
+                ],
+            ],
+        };
     }
 
     /**
@@ -1205,10 +1241,19 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
 
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                $operator => [
+                    [
+                        '$month' => '$'.$column
+                    ],
+                    $value,
+                ],
+            ],
+        ];
     }
 
     /**
@@ -1219,10 +1264,19 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
+        $value = str_starts_with($value, '0') ? intval(str_replace('0', '', $value)) : $value;
 
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                $operator => [
+                    [
+                        '$dayOfMonth' => '$'.$column
+                    ],
+                    $value,
+                ],
+            ],
+        ];
     }
 
     /**
@@ -1233,10 +1287,18 @@ class Builder extends BaseBuilder
     {
         extract($where);
 
-        $where['operator'] = $operator;
-        $where['value'] = $value;
+        $operator = $operator === '=' ? '$eq' : $this->conversion[$operator];
 
-        return $this->compileWhereBasic($where);
+        return [
+            '$expr' => [
+                $operator => [
+                    [
+                        '$year' => '$'.$column
+                    ],
+                    $value
+                ],
+            ],
+        ];
     }
 
     /**

--- a/tests/Models/Birthday.php
+++ b/tests/Models/Birthday.php
@@ -18,4 +18,8 @@ class Birthday extends Eloquent
     protected $connection = 'mongodb';
     protected $collection = 'birthday';
     protected $fillable = ['name', 'birthday', 'time'];
+
+    protected $casts = [
+        'birthday' => 'datetime',
+    ];
 }

--- a/tests/Models/Birthday.php
+++ b/tests/Models/Birthday.php
@@ -11,14 +11,11 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  *
  * @property string $name
  * @property string $birthday
- * @property string $day
- * @property string $month
- * @property string $year
  * @property string $time
  */
 class Birthday extends Eloquent
 {
     protected $connection = 'mongodb';
     protected $collection = 'birthday';
-    protected $fillable = ['name', 'birthday', 'day', 'month', 'year', 'time'];
+    protected $fillable = ['name', 'birthday', 'time'];
 }

--- a/tests/Models/Birthday.php
+++ b/tests/Models/Birthday.php
@@ -17,7 +17,7 @@ class Birthday extends Eloquent
 {
     protected $connection = 'mongodb';
     protected $collection = 'birthday';
-    protected $fillable = ['name', 'birthday', 'time'];
+    protected $fillable = ['name', 'birthday'];
 
     protected $casts = [
         'birthday' => 'datetime',

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -757,6 +757,26 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->whereYear('created_at', '>', '2023'),
         ];
 
+        yield 'where time' => [
+            ['find' => [['$expr' => [
+                '$eq' => [
+                    ['$dateToString' => ['date' => '$created_at', 'format' => '%H:%M:%S']],
+                    '10:11:12',
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereTime('created_at', '10:11:12'),
+        ];
+
+        yield 'where time >' => [
+            ['find' => [['$expr' => [
+                '$gt' => [
+                    ['$dateToString' => ['date' => '$created_at', 'format' => '%H:%M:%S']],
+                    '10:11:12',
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereTime('created_at', '>', '10:11:12'),
+        ];
+
         /** @see DatabaseQueryBuilderTest::testBasicSelectDistinct */
         yield 'distinct' => [
             ['distinct' => ['foo', [], []]],

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -661,6 +661,14 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->whereDate('created_at', '=', new DateTimeImmutable('2018-09-30 15:00:00 +02:00')),
         ];
 
+        yield 'where date !=' => [
+            ['find' => [['$or' => [
+                ['created_at' => ['$lt' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00'))]],
+                ['created_at' => ['$gt' => new UTCDateTime(new DateTimeImmutable('2018-09-30 23:59:59.999 +00:00'))]],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '!=', '2018-09-30'),
+        ];
+
         yield 'where date <' => [
             ['find' => [['created_at' => [
                 '$lt' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00')),

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -645,6 +645,110 @@ class BuilderTest extends TestCase
             fn (Builder $builder) => $builder->where('name', 'not regex', '/^acme$/si'),
         ];
 
+        yield 'where date' => [
+            ['find' => [['created_at' => [
+                '$gte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00')),
+                '$lte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 23:59:59.999 +00:00')),
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '2018-09-30'),
+        ];
+
+        yield 'where date DateTimeImmutable' => [
+            ['find' => [['created_at' => [
+                '$gte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00')),
+                '$lte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 23:59:59.999 +00:00')),
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '=', new DateTimeImmutable('2018-09-30 15:00:00 +02:00')),
+        ];
+
+        yield 'where date <' => [
+            ['find' => [['created_at' => [
+                '$lt' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00')),
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '<', '2018-09-30'),
+        ];
+
+        yield 'where date >=' => [
+            ['find' => [['created_at' => [
+                '$gte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 00:00:00.000 +00:00')),
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '>=', '2018-09-30'),
+        ];
+
+        yield 'where date >' => [
+            ['find' => [['created_at' => [
+                '$gt' => new UTCDateTime(new DateTimeImmutable('2018-09-30 23:59:59.999 +00:00')),
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '>', '2018-09-30'),
+        ];
+
+        yield 'where date <=' => [
+            ['find' => [['created_at' => [
+                '$lte' => new UTCDateTime(new DateTimeImmutable('2018-09-30 23:59:59.999 +00:00')),
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDate('created_at', '<=', '2018-09-30'),
+        ];
+
+        yield 'where day' => [
+            ['find' => [['$expr' => [
+                '$eq' => [
+                    ['$dayOfMonth' => '$created_at'],
+                    5,
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDay('created_at', 5),
+        ];
+
+        yield 'where day > string' => [
+            ['find' => [['$expr' => [
+                '$gt' => [
+                    ['$dayOfMonth' => '$created_at'],
+                    5,
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereDay('created_at', '>', '05'),
+        ];
+
+        yield 'where month' => [
+            ['find' => [['$expr' => [
+                '$eq' => [
+                    ['$month' => '$created_at'],
+                    10,
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereMonth('created_at', 10),
+        ];
+
+        yield 'where month > string' => [
+            ['find' => [['$expr' => [
+                '$gt' => [
+                    ['$month' => '$created_at'],
+                    5,
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereMonth('created_at', '>', '05'),
+        ];
+
+        yield 'where year' => [
+            ['find' => [['$expr' => [
+                '$eq' => [
+                    ['$year' => '$created_at'],
+                    2023,
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereYear('created_at', 2023),
+        ];
+
+        yield 'where year > string' => [
+            ['find' => [['$expr' => [
+                '$gt' => [
+                    ['$year' => '$created_at'],
+                    2023,
+                ],
+            ]], []]],
+            fn (Builder $builder) => $builder->whereYear('created_at', '>', '2023'),
+        ];
+
         /** @see DatabaseQueryBuilderTest::testBasicSelectDistinct */
         yield 'distinct' => [
             ['distinct' => ['foo', [], []]],

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -31,6 +31,7 @@ class QueryTest extends TestCase
         Birthday::create(['name' => 'Robert Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:14'), 'time' => '10:53:14']);
         Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:15'), 'time' => '10:53:15']);
         Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2022-05-12 10:53:16'), 'time' => '10:53:16']);
+        Birthday::create(['name' => 'Boo']);
     }
 
     public function tearDown(): void
@@ -217,6 +218,9 @@ class QueryTest extends TestCase
 
         $birthdayCount = Birthday::whereDate('birthday', '<=', '2021-05-11')->get();
         $this->assertCount(2, $birthdayCount);
+
+        $birthdayCount = Birthday::whereDate('birthday', '<>', '2021-05-11')->get();
+        $this->assertCount(5, $birthdayCount);
     }
 
     public function testWhereDay(): void
@@ -240,10 +244,10 @@ class QueryTest extends TestCase
         $this->assertCount(5, $month);
 
         $month = Birthday::whereMonth('birthday', '<', '10')->get();
-        $this->assertCount(6, $month);
+        $this->assertCount(7, $month);
 
         $month = Birthday::whereMonth('birthday', '<>', '5')->get();
-        $this->assertCount(1, $month);
+        $this->assertCount(2, $month);
     }
 
     public function testWhereYear(): void
@@ -255,10 +259,10 @@ class QueryTest extends TestCase
         $this->assertCount(1, $year);
 
         $year = Birthday::whereYear('birthday', '<', '2021')->get();
-        $this->assertCount(1, $year);
+        $this->assertCount(2, $year);
 
         $year = Birthday::whereYear('birthday', '<>', '2021')->get();
-        $this->assertCount(2, $year);
+        $this->assertCount(3, $year);
     }
 
     public function testWhereTime(): void

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Jenssegers\Mongodb\Tests;
 
+use DateTimeImmutable;
 use Jenssegers\Mongodb\Tests\Models\Birthday;
 use Jenssegers\Mongodb\Tests\Models\Scoped;
 use Jenssegers\Mongodb\Tests\Models\User;
@@ -24,12 +25,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2020-04-10', 'day' => '10', 'month' => '04', 'year' => '2020', 'time' => '10:53:11']);
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:12']);
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => '2021-05-11', 'day' => '11', 'month' => '05', 'year' => '2021', 'time' => '10:53:13']);
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:14']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2021-05-12', 'day' => '12', 'month' => '05', 'year' => '2021', 'time' => '10:53:15']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => '2022-05-12', 'day' => '12', 'month' => '05', 'year' => '2022', 'time' => '10:53:16']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2020-04-10 10:53:11'), 'time' => '10:53:11']);
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:12'), 'time' => '10:53:12']);
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => new DateTimeImmutable('2021-05-11 10:53:13'), 'time' => '10:53:13']);
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:14'), 'time' => '10:53:14']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:15'), 'time' => '10:53:15']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2022-05-12 10:53:16'), 'time' => '10:53:16']);
     }
 
     public function tearDown(): void
@@ -204,36 +205,60 @@ class QueryTest extends TestCase
 
         $birthdayCount = Birthday::whereDate('birthday', '2021-05-11')->get();
         $this->assertCount(1, $birthdayCount);
+
+        $birthdayCount = Birthday::whereDate('birthday', '>', '2021-05-11')->get();
+        $this->assertCount(4, $birthdayCount);
+
+        $birthdayCount = Birthday::whereDate('birthday', '>=', '2021-05-11')->get();
+        $this->assertCount(5, $birthdayCount);
+
+        $birthdayCount = Birthday::whereDate('birthday', '<', '2021-05-11')->get();
+        $this->assertCount(1, $birthdayCount);
+
+        $birthdayCount = Birthday::whereDate('birthday', '<=', '2021-05-11')->get();
+        $this->assertCount(2, $birthdayCount);
     }
 
     public function testWhereDay(): void
     {
-        $day = Birthday::whereDay('day', '12')->get();
+        $day = Birthday::whereDay('birthday', '12')->get();
         $this->assertCount(4, $day);
 
-        $day = Birthday::whereDay('day', '11')->get();
+        $day = Birthday::whereDay('birthday', '11')->get();
         $this->assertCount(1, $day);
     }
 
     public function testWhereMonth(): void
     {
-        $month = Birthday::whereMonth('month', '04')->get();
+        $month = Birthday::whereMonth('birthday', '04')->get();
         $this->assertCount(1, $month);
 
-        $month = Birthday::whereMonth('month', '05')->get();
+        $month = Birthday::whereMonth('birthday', '05')->get();
         $this->assertCount(5, $month);
+
+        $month = Birthday::whereMonth('birthday', '>=', '5')->get();
+        $this->assertCount(5, $month);
+
+        $month = Birthday::whereMonth('birthday', '<', '10')->get();
+        $this->assertCount(6, $month);
+
+        $month = Birthday::whereMonth('birthday', '<>', '5')->get();
+        $this->assertCount(1, $month);
     }
 
     public function testWhereYear(): void
     {
-        $year = Birthday::whereYear('year', '2021')->get();
+        $year = Birthday::whereYear('birthday', '2021')->get();
         $this->assertCount(4, $year);
 
-        $year = Birthday::whereYear('year', '2022')->get();
+        $year = Birthday::whereYear('birthday', '2022')->get();
         $this->assertCount(1, $year);
 
-        $year = Birthday::whereYear('year', '<', '2021')->get();
+        $year = Birthday::whereYear('birthday', '<', '2021')->get();
         $this->assertCount(1, $year);
+
+        $year = Birthday::whereYear('birthday', '<>', '2021')->get();
+        $this->assertCount(2, $year);
     }
 
     public function testWhereTime(): void

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -25,12 +25,12 @@ class QueryTest extends TestCase
         User::create(['name' => 'Tommy Toe', 'age' => 33, 'title' => 'user']);
         User::create(['name' => 'Yvonne Yoe', 'age' => 35, 'title' => 'admin']);
         User::create(['name' => 'Error', 'age' => null, 'title' => null]);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2020-04-10 10:53:11'), 'time' => '10:53:11']);
-        Birthday::create(['name' => 'Jane Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:12'), 'time' => '10:53:12']);
-        Birthday::create(['name' => 'Harry Hoe', 'birthday' => new DateTimeImmutable('2021-05-11 10:53:13'), 'time' => '10:53:13']);
-        Birthday::create(['name' => 'Robert Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:14'), 'time' => '10:53:14']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:15'), 'time' => '10:53:15']);
-        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2022-05-12 10:53:16'), 'time' => '10:53:16']);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2020-04-10 10:53:11')]);
+        Birthday::create(['name' => 'Jane Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:12')]);
+        Birthday::create(['name' => 'Harry Hoe', 'birthday' => new DateTimeImmutable('2021-05-11 10:53:13')]);
+        Birthday::create(['name' => 'Robert Doe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:14')]);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2021-05-12 10:53:15')]);
+        Birthday::create(['name' => 'Mark Moe', 'birthday' => new DateTimeImmutable('2022-05-12 10:53:16')]);
         Birthday::create(['name' => 'Boo']);
     }
 
@@ -267,11 +267,17 @@ class QueryTest extends TestCase
 
     public function testWhereTime(): void
     {
-        $time = Birthday::whereTime('time', '10:53:11')->get();
+        $time = Birthday::whereTime('birthday', '10:53:11')->get();
         $this->assertCount(1, $time);
 
-        $time = Birthday::whereTime('time', '>=', '10:53:14')->get();
+        $time = Birthday::whereTime('birthday', '>=', '10:53:14')->get();
         $this->assertCount(3, $time);
+
+        $time = Birthday::whereTime('birthday', '!=', '10:53:14')->get();
+        $this->assertCount(6, $time);
+
+        $time = Birthday::whereTime('birthday', '<', '10:53:12')->get();
+        $this->assertCount(2, $time);
     }
 
     public function testOrder(): void


### PR DESCRIPTION
Fix [PHPORM-60](https://jira.mongodb.org/browse/PHPORM-60)

Created from https://github.com/jenssegers/laravel-mongodb/pull/2376

> So basically, current whereDate, whereDay, whereMonth and whereYear is query on different column with specific need (like whereDate you need column that has value YYYY-MM-DD etc) using basic comparison.
>
> As we all know that isnt how whereDate works on sql, this PR will generate query using built in $dayOfMonth, $month, $year on whereDay, whereMonth, and whereYear, while whereDate basically generate range date(since mongodb doesnt have date() equivalent like on sql).

- `whereDate` uses `$lt` & `$gt` comparison with `UTCDateTime` objects
- `whereDay` uses `$dayOfWeek`
- `whereMonth` uses `$month`
- `whereYear` uses `$year`
- `whereTime` uses `$dateToString` to format into `H:M:S`
